### PR TITLE
Update & Bug fix

### DIFF
--- a/C#/ReadMe.md
+++ b/C#/ReadMe.md
@@ -9,40 +9,40 @@ c# 최고 성능을 제공한다는 직렬화 라이브러리들보다 수배에
 <br>
 
 - CGD.buffer의  특징
-   - 매우 간단(Append/Extract/SetFront/GetFront/GetSizeOf가 사실상 대부분...)<br>
-   - 초고성능 (Reflection & Roslyn & Souce Generator로 제작되어 압도적 성능을 자랑합니다.)<br>
+   - 매우 간단(``Append``/``Extract``/``SetFront``/``GetFront``/``GetSizeOf``가 사실상 대부분...)<br>
+   - 초고성능 (``Reflection`` & ``Roslyn`` & ``Souce Generator``로 제작되어 압도적 성능을 자랑합니다.)<br>
    - 작고 가볍습니다.<br>
    - Schemaless와 Schema(구조체 직렬화)를 모두 지원<br>
    - 설정이나 스크립트(IDL)없이 구조체를 그대로 Schema로 사용 가능<br>
    - 지원되는 자료형은<br>
-      * 기본 자료형(char,byte,sbyte,int,uint,long,ulong,float,double)<br>
-      * enum<br>
-      * 문자열(string)<br>
-      * 배열(T[N])<br>
-      * 컬렉션(List<T>, Dictionary<K,V>)<br>
-      * 시간(DateTime) <br>
-      * CGDK.buffer<br>
+      * 기본 자료형(``char``,``byte``,``sbyte``,``int``,``uint``,``long``,``ulong``,``float``,``double``)<br>
+      * ``enum``<br>
+      * 문자열(``string``)<br>
+      * 배열(``T[N]``)<br>
+      * 컬렉션(``List<T>``, ``Dictionary<K,V>``)<br>
+      * 시간(``DateTime``) <br>
+      * ``CGDK.buffer``<br>
       * struct<br>
       * class<br>
       * IBufferSerialzable<br>
-   - Reflection과 Roslyn & Source Generator를 사용하여 구현하였습니다.<br>
-     (Roslyn과 Source Generator의 성능 버프를 받으시려면 CGDK.buffer.Generator도 nuget으로 설치를 하셔야 합니다.)
-   - C++ 버전인 CGDK::buffer와 호환됩니다.<br>
+   - ``Reflection``과 ``Roslyn`` & ``Source Generator``를 사용하여 구현하였습니다.<br>
+     (``Roslyn``과 ``Source Generator``의 성능 버프를 받으시려면 ``CGDK.buffer.Generator``도 nuget으로 설치를 하셔야 합니다.)
+   - C++ 버전인 ``CGDK::buffer``와 호환됩니다.<br>
 <br>
 <br>
 
 ## CGD.buffer 설치 및 적용하기
 ### 1. 설치하기
 #### nuget으로 설치하기<br>
-   - 설치를 원하는 project에서 'Nuget 패키지 관리' 창을 열어 '찾아 보기'에서 'CGDK'로 검색하시면<br>
-   - 'CGDK.buffer'와 'CGDK.buffer.Generator'를 찾을 수 있습니다.<br>
+   - 설치를 원하는 project에서 'Nuget 패키지 관리' 창을 열어 '찾아 보기'에서 ``CGDK``로 검색하시면<br>
+   - ``CGDK.buffer``와 ``CGDK.buffer.Generator``를 찾을 수 있습니다.<br>
      이 두 패키지를 설치해 주십시요.<br>
-   - 'CGDK.buffer'만 설치하셔도 되지만 더 높은 성능을 원하시면 CGDK.buffer.Generator를 같이 설치하는 것을 권장드립니다.<br>
+   - ``CGDK.buffer``만 설치하셔도 되지만 더 높은 성능을 원하시면 ``CGDK.buffer.Generator``를 같이 설치하는 것을 권장드립니다.<br>
 
 #### 수동 설치하기<br>
-   - 'CGDK.buffer.dll'과 'CGDK.buffer.Generator.dll'을 다운 혹은 직접 컴파일해 직접 dll 파일을 포함시켜 설정할 수 있습니다.
-   - 설치를 원하는 프로젝트의 '종속성/프로젝트 참조 추가'로 'CGDK.buffer.dll'과 'CGDK.buffer.Generator.dll'을  추가해 주시면 됩니다.<br>
-   - 직접 .csproj을 택스트로 열어서 CGDK.buffer.Generator.dll는 아래와 같이 직접 수정해 주셔야 합니다.<br>
+   - ``CGDK.buffer.dll``과 ``CGDK.buffer.Generator.dll``을 다운 혹은 직접 컴파일해 직접 dll 파일을 포함시켜 설정할 수 있습니다.
+   - 설치를 원하는 프로젝트의 '종속성/프로젝트 참조 추가'로 ``CGDK.buffer.dll``과 ``CGDK.buffer.Generator.dll``을  추가해 주시면 됩니다.<br>
+   - 직접 ``.csproj``을 택스트로 열어서 ``CGDK.buffer.Generator.dll``는 아래와 같이 직접 수정해 주셔야 합니다.<br>
 
       ``` XML
       <ItemGroup>
@@ -50,22 +50,23 @@ c# 최고 성능을 제공한다는 직렬화 라이브러리들보다 수배에
       </ItemGroup>
       ```
       이렇게 포함시켜 주십시요.<br>
-   - .NET framework 버전의 경우 'CGDK.buffer.NET.framework.dll'파일을 수동으로 '참조 추가'를 통해 추가해 주시면 됩니다.<br>
+   - ``.NET framework`` 버전의 경우 ``CGDK.buffer.NET.framework.dll``파일을 수동으로 '참조 추가'를 통해 추가해 주시면 됩니다.<br>
 
 ### 2. 초기화 하기<br>
-   - 'CGDK.buffer'만 설치했다면 특별히 초기화를 할 필요가 없습니다.<br>
-   - 'CGDK.buffer.Generator'까지 설치했다면 활성화를 위해 프로그램 시작 부분에서 초기화를 위한 함수를 호출해 주어야 합니다.<br>
+   - ``CGDK.buffer``만 설치했다면 특별히 초기화를 할 필요가 없습니다.<br>
+   - ``CGDK.buffer.Generator``까지 설치했다면 활성화를 위해 프로그램 시작 부분에서 초기화를 위한 함수를 호출해 주어야 합니다.<br>
       ``` C#
          CGDK.BufferSerializer.Generator.Initialize();
       ```
    
       이 함수를 호출해 주어야 합니다.<br>
-      호출해 주지 않아도 동작은 하지만 'CGDK.buffer.Generator'가 적용 되지 않아 향상된 성능을 제공하지 않습니다.<br>
-
+      호출해 주지 않아도 동작은 하지만 ``CGDK.buffer.Generator``가 적용 되지 않아 향상된 성능을 제공하지 않습니다.<br>
+<br>
+<br>
 
 ## CGD.buffer 직렬화/역직렬화 하기
 ### 1. 직렬화하기(Schemaless)  
-   버퍼에 데이터 쓰기는 CGDK.buffer의 멤버 함수인 Append<T>(...)로 간단히 가능합니다.<br>
+   버퍼에 데이터 쓰기는 ``CGDK.buffer``의 멤버 함수인 ``Append<T>(...)``로 간단히 가능합니다.<br>
 
    ``` C#
    // CGDK.buffer를 생성하고 메모리 256byte를 할당합니다.
@@ -78,6 +79,7 @@ c# 최고 성능을 제공한다는 직렬화 라이브러리들보다 수배에
    buf.Append<string>("Test String");	// 문자열을 직렬화합니다.
    ```
    데이터형을 생략할 경우 인자의 자료형으로 인식합니다.<br>
+<br>
 
 ### 2. 역직렬화하기(Schemaless)<br>
 - Extract<T>() 멤버 함수로 간단히 역직렬화를 할 수 있습니다.<br>
@@ -91,7 +93,7 @@ c# 최고 성능을 제공한다는 직렬화 라이브러리들보다 수배에
    ```
 
 - 컬렉션 직렬화/역직렬화<br> 
-C#의 List<T>, Dictionary<K,V> ... 등의 데이터도 직렬화/역직렬화 가능합니다.<br/>
+``C#의 List<T>``, ``Dictionary<K,V>`` ... 등의 데이터도 직렬화/역직렬화 가능합니다.<br/>
 
    ``` C#
    List<int>                      listTest = new ...;
@@ -113,12 +115,13 @@ C#의 List<T>, Dictionary<K,V> ... 등의 데이터도 직렬화/역직렬화 �
    var temp3 = buf.Extract<Dictionary<string,int>> ();
    var temp4 = buf.Extract<Dictionary<string,List<int>>> ();
    ```
+<br>
 
 ### 3. 구조체 직렬화
-직렬화 대상 구조체는 '[CGDK.Attribute.Serializable]' Attribue를 붙혀 주어야 합니다.<br>
-또 구조체가 static이 아니어야 하며 public 속성을 가져야 합니다.<br/>
-구조체의 멤버 변수들은 기본적으로 모두 직렬화의 대상이 됩니다만 public 속성이 아니거나 const, read_only,write_only 같은 속성이 가지면 직렬화에서 제외됩니다.<br/>
-특별히 직렬화/역직렬화에서 제외하고 싶으면 '[CGDK.Attribute.Filed(false)]'를 붙혀주면 됩니다.<br/>
+직렬화 대상 구조체는 ``[CGDK.Attribute.Serializable]'``Attribue를 붙혀 주어야 합니다.<br>
+또 구조체가 ``static``이 아니어야 하며 ``public`` 속성을 가져야 합니다.<br/>
+구조체의 멤버 변수들은 기본적으로 모두 직렬화의 대상이 됩니다만 ``public`` 속성이 아니거나 ``const``, ``read_only``, ``write_only`` 같은 속성이 가지면 직렬화에서 제외됩니다.<br/>
+특별히 직렬화/역직렬화에서 제외하고 싶으면 ``[CGDK.Attribute.Filed(false)]``를 붙혀주면 됩니다.<br/>
 
 ``` C#
 [CGDK.Attribute.Serializable]
@@ -137,11 +140,11 @@ public struct TEST
 <br>
 
 ### 4. 클래스 직렬화
-직렬화 대상 클래서는 '[CGDK.Attribute.Serializable]' Attribue를 붙혀 줘야 합니다.<br/>
-또 클래스가 static이 아니어야 하며 public 속성을 가져야 합니다.<br/>
+직렬화 대상 클래서는 ``[CGDK.Attribute.Serializable]`` Attribue를 붙혀 줘야 합니다.<br/>
+또 클래스가 static이 아니어야 하며 ``public`` 속성을 가져야 합니다.<br/>
 클래스의 멤버 변수는 기본적으로 구조체와 반대로 직렬화의 대상이 아닌 것으로 간주합니다.<br/>
-직렬화를 하고자 하는 멤버만 '[CGDK.Attribute.Filed]'를 붙혀 줘야 합니다.<br/>
-또 이 멤버는 public 속성이어야 하며 const, read_only,write_only 속성을 가져서는 안됩니다.<br/>
+직렬화를 하고자 하는 멤버만 ``[CGDK.Attribute.Filed]``를 붙혀 줘야 합니다.<br/>
+또 이 멤버는 public 속성이어야 하며 ``const``, ``read_only``, ``write_only`` 속성을 가져서는 안됩니다.<br/>
 
 ``` C#
 [CGDK.Attribute.Serializable]
@@ -163,10 +166,9 @@ public class TEST
 하지만 상속이 가능하다는 장점도 있습니다.<br/>
 따라서 매우 빈번하게 사용되는 메시지는 구조체를 사용하고, 빈번하지 않으며 복잡한 메시지만 클래스를 사용하는 것이 좋은 선택일 수 있습니다.<br/>
 <br/>
-<br>
 
 ### 5. 직렬화에 필요한 메모리 크기 구하기<br>
-- CGDK.GetSizeOf<V>(...)를 사용해 데이터 직렬화 했을 때의 크기를 얻을 수 있습니다. <br>
+- ``CGDK.GetSizeOf<V>(...)``를 사용해 데이터 직렬화 했을 때의 크기를 얻을 수 있습니다. <br>
 
    ``` C#
    var maplistTemp = new Dictionary<int,string>();
@@ -176,7 +178,7 @@ public class TEST
    ```
 <br>
 
-- 구조체나 클래스 역시 GetSizeOf<T>()함수로 직렬화 크기를 구할 수 있습니다.
+- 구조체나 클래스 역시 ``GetSizeOf<T>()``함수로 직렬화 크기를 구할 수 있습니다.
 
    ``` C#
    var temp = new TEST();
@@ -184,25 +186,25 @@ public class TEST
    // - temp를 직렬화 했을 때 크기
    var size = CGDK.buffer.GetSizeOf(temp);
    ```
-- 다만 GetSizeOf<T>()함수는 동적 처리 함수이므로 실시간 비용이 발생합니다. 큰 비용은 아니더라도 고려해 사용할 필요는 있습니다.<br/>
+- 다만 ``GetSizeOf<T>()``함수는 동적 처리 함수이므로 실시간 비용이 발생합니다. 큰 비용은 아니더라도 고려해 사용할 필요는 있습니다.<br/>
 <br/>
 
 ### 6. 동적 메모리 할당 받기<br>
 버퍼에 메모리를 설정하는 방법은 3가지 방법이 가능합니다.
-- buffer의 생성자에서 바로 생성하기 (생성자에서)
+- ``buffer``의 생성자에서 바로 생성하기 (생성자에서)
    ``` C#
    // 1000byte 메모리를 동적 할당 받는다.
    var buf = new CGDK.buffer(1000);
    ```
 
-- buffer의 생성 후 할당하기 (Alloc함수로)
+- ``buffer``의 생성 후 할당하기 (Alloc함수로)
    ``` C#
    // 1000byte 메모리를 동적 할당 받는다.
    var buf = new CGDK.buffer();
    buf.Alloc(1000);
    ```
 
-- 외부에서 생성해서 buffer에 설정해 넣기 (대입해 넣기)
+- 외부에서 생성해서 ``buffer``에 설정해 넣기 (대입해 넣기)
    ``` C#
    // 1000byte 메모리를 동적 할당 받는다.
    var temp = new byte[1000];
@@ -218,44 +220,46 @@ public class TEST
    var buf = new CGDK.buffer();
    buf.SetBuffer(temp, 0, 0); // 0은 offset과 count값입니다.
    ```
-<br/>
-GetSizeOf<T>()와 함께 사용하면 직렬화 크기에 딱 맞는 버퍼의 할당이 가능합니다.<br/>
+   <br/>
 
-``` C#
-// 1000byte 메모리를 동적 할당 받는다.
-TEST temp = new TEMP();
-...
 
-var buf = new CGDK.buffer(CGDK.buffer.GetSizeOf(temp));
-buf.Append(temp);
-```
+   ``GetSizeOf<T>()``와 함께 사용하면 직렬화 크기에 딱 맞는 버퍼의 할당이 가능합니다.<br/>
 
-할당받은 버퍼를 비우려면... __Clear()__ 를 하면 됩니다.
-Clear()함수는 Offset과 Count만 0로 만들 뿐만 아니라 앗사리 할당된 메모리를 null로 초기화합니다.
-``` C#
-// 1000byte 메모리를 동적 할당 받는다.
-var buf = new CGDK.buffer();
+   ``` C#
+   // 1000byte 메모리를 동적 할당 받는다.
+   TEST temp = new TEMP();
+   ...
 
-// - 메모리를 할당받지 않았으니 empty == true
-var is_empty1 = buf.IsEmpty(); // true
+   var buf = new CGDK.buffer(CGDK.buffer.GetSizeOf(temp));
+   buf.Append(temp);
+   ```
 
-// - 256byte의 메모리를 할당받는다.
-var buf.Alloc(256);
+   할당받은 버퍼를 비우려면... __``Clear()``__ 를 하면 됩니다.
+   ``Clear()``함수는 ``Offset``과 ``Count``만 0로 만들 뿐만 아니라 앗사리 할당된 메모리를 ``null``로 초기화합니다.
+   ``` C#
+   // 1000byte 메모리를 동적 할당 받는다.
+   var buf = new CGDK.buffer();
 
-// - 당연히 empty == false!
-var is_empty2 = buf.IsEmpty(); // false
+   // - 메모리를 할당받지 않았으니 empty == true
+   var is_empty1 = buf.IsEmpty(); // true
 
-// - 버퍼를 할당해제한다.
-buf.Clear();
+   // - 256byte의 메모리를 할당받는다.
+   var buf.Alloc(256);
 
-// - Clear()후면 Empty상태가 된다.
-var is_empty3 = buf.IsEmpty(); // true
-```
+   // - 당연히 empty == false!
+   var is_empty2 = buf.IsEmpty(); // false
+
+   // - 버퍼를 할당해제한다.
+   buf.Clear();
+
+   // - Clear()후면 Empty상태가 된다.
+   var is_empty3 = buf.IsEmpty(); // true
+   ```
 <br>
 
 ### 7. 읽어만 내기
-- 버퍼 값의 변경 없이 데이터만 읽어 내고 싶다면 __GetFront<T>([offset])__ 을 사용하면 됩니다.
-  (Extract<T>를 사용해도 값을 읽어낼 수 있지만 그 만큼의 오프셋과 크기가 변경됩니다.)<br/>
+- 버퍼 값의 변경 없이 데이터만 읽어 내고 싶다면 __``GetFront<T>([offset])``__ 을 사용하면 됩니다.
+  (``Extract<T>``를 사용해도 값을 읽어낼 수 있지만 그 만큼의 오프셋과 크기가 변경됩니다.)<br/>
   
 
    ``` C#
@@ -271,8 +275,8 @@ var is_empty3 = buf.IsEmpty(); // true
    var tenp2 = buf.GetFront<string>(12); // 
    ```
 
-- GetFront<T>()의 실행으로 변경된 Offset을 얻고 싶다면 __CGDK.Offset__ 을 사용하면 됩니다.<br/>
-Offset을 사용해 GetFront<T>를 수행하면 읽어낸 만큼 Offset값을 업데이트 해주므로 연속적으로 Offset을 사용해 값을 읽어낼 수 있습니다.<br/>
+- ``GetFront<T>()``의 실행으로 변경된 Offset을 얻고 싶다면 __``CGDK.Offset``__ 을 사용하면 됩니다.<br/>
+``Offset``을 사용해 GetFront<T>를 수행하면 읽어낸 만큼 Offset값을 업데이트 해주므로 연속적으로 Offset을 사용해 값을 읽어낼 수 있습니다.<br/>
 
    ``` C#
    var buf = new CGDK.buffer(1024);
@@ -287,15 +291,15 @@ Offset을 사용해 GetFront<T>를 수행하면 읽어낸 만큼 Offset값을 �
    var temp1 = buf.GetFront<long>(ref temp_offset); // temp1는 200이 되며 temp_offset값은 12로 변경됩니다.
    var tenp2 = buf.GetFront<string>(ref temp_offset); // temp2는 "test"가 될 것이며 temp_offset값은 20로 변경됩니다.
    ```
-- 주의) 타입 안정성은 제공하지는 않습니다. 즉 GetFront<int>(8)는 그냥 8Byte Offset이 떨어진 값을 int로 가정해서 읽어올 뿐입니다.<br/>
-  원래 데이터 형이 int가 아닐 경우 원하지 않는 값을 얻을 수도 있습니다.<br/>
+- 주의) 타입 안정성은 제공하지는 않습니다. 즉 ``GetFront<int>(8)``는 그냥 8Byte Offset이 떨어진 값을 int로 가정해서 읽어올 뿐입니다.<br/>
+  원래 데이터 형이 ``int``가 아닐 경우 원하지 않는 값을 얻을 수도 있습니다.<br/>
 타입 안정성을 제공하지 않아 사용상의 편리함은 있을 수 있습니다만 예외를 발생시킬 수도 있으므로 잘 사용할 필요가 있습니다.<br>
 <br>
 
 ### 8. 덥어 쓰기
 - 이미 쓰여진 데이터를 덥어 쓰거나 먼저 버퍼에 값을 써넣은 후 추후 값을 써넣어야 하는 경우가 있을 수 있습니다.<br/>
-  이럴 때 __SetFront<T>([값], [offset])__ 함수를 사용하시면 됩니다.<br>
-  (Append<T>는 버퍼읠 제일 끝에만 붙이는 처리입니다.<br/>)
+  이럴 때 __``SetFront<T>([값], [offset])``__ 함수를 사용하시면 됩니다.<br>
+  (``Append<T>``는 버퍼읠 제일 끝에만 붙이는 처리입니다.<br/>)
  
    ``` C#
    var buf = new CGDK.buffer(1024);
@@ -307,14 +311,14 @@ Offset을 사용해 GetFront<T>를 수행하면 읽어낸 만큼 Offset값을 �
    // 여기서는 buf의 직렬화한 길이를 써넣었습니다.
    buf.SetFront<long>(buf.Count, 4); // 4Byte offset 떨어진 곳에 long형으로 buf.Count(버퍼의 길이)를 써넣는다.
    ```
-- SetFront<T>() 함수의 리턴값을 값을 써넣은 후에 변경된 Offset값을 돌려 줍니다.<br>
+- ``SetFront<T>()`` 함수의 리턴값을 값을 써넣은 후에 변경된 Offset값을 돌려 줍니다.<br>
 이 값을 받아 값을 읽거나 써넣는 데에 사용할 수 있습니다.<br>
 하지만 타입 안정성을 제공하지 않으므로 주의해서 사용할 필요가 있습니다.<br>
 <br>
 
 
 ## CGD.buffer 구조<br/>
-CGDK.buffer의 멤버변수는 buffer, m_offset, m_count 3개의 멤버 변수로 구성되어 있습니다.
+``CGDK.buffer``의 멤버변수는 ``m_buffer``, ``m_offset``, ``m_count`` 3개의 멤버 변수로 구성되어 있습니다.
 
    ``` C#
 	// 1) Buffer
@@ -326,17 +330,17 @@ CGDK.buffer의 멤버변수는 buffer, m_offset, m_count 3개의 멤버 변수�
 	// 3) 사용 길이 (m_iOffset부터 Buffer중 사용하는 끝까지의 길이)
 	private int			m_count;
    ```
-   - m_buffer는 byte의 배열이며 실제 데이터를 써넣은 배열 객체입니다.<br/>
-   - m_offset은 데이터가 쓰여진 처음 위치의 offset을 말합니다.<br/>
-     m_offset값이 5면 m_buffer[5]부터 데이터가 있다는 뜻입니다.<br/>
-     Extract<T>()를 하면 읽어낸 Byte만큼 더해집니다.<br/>
-   - m_count는 쓰여진 데이터의 바이트 수입니다.<br/>
-     Append<T>(...)를 하면 쓰여진 Byte 수만큼 더해집니다.<br/>
+   - ``m_buffer``는 byte의 배열이며 실제 데이터를 써넣은 배열 객체입니다.<br/>
+   - ``m_offset``은 데이터가 쓰여진 처음 위치의 offset을 말합니다.<br/>
+     ``m_offset``값이 5면 ``m_buffer[5]``부터 데이터가 있다는 뜻입니다.<br/>
+     ``Extract<T>()``를 하면 읽어낸 Byte만큼 더해집니다.<br/>
+   - ``m_count``는 쓰여진 데이터의 바이트 수입니다.<br/>
+     ``Append<T>(...)``를 하면 쓰여진 Byte 수만큼 더해집니다.<br/>
 <br/>
 
-   즉, m_buffer 배열에서 m_offset부터 m_count만큼의 데이터가 존재한다는 의미입니다.<br/>
+   즉, ``m_buffer`` 배열에서 ``m_offset``부터 ``m_count``만큼의 데이터가 존재한다는 의미입니다.<br/>
    <br/>
-   이 값들은 다음과 같이 Offset과 Count 프라퍼티를 사용해 직접 읽거나 쓸 수도 있습니다.<br/>
+   이 값들은 다음과 같이 ``Offset``과 ``Count`` 프라퍼티를 사용해 직접 읽거나 쓸 수도 있습니다.<br/>
    
 
    ``` C#
@@ -376,7 +380,7 @@ CGDK.buffer의 멤버변수는 buffer, m_offset, m_count 3개의 멤버 변수�
    var s6 = buf.Count;  // s6값은 0일 것입니다.
    var f6 = buf.Offset; // f6값은 14일 것입니다.      
    ```
-   Count와 Offset 값을 대입을 통해 직접 변경은 가능하지만 되도록이면 직접 값을 써넣는 일은 피하시길 권장합니다.
+   ``Count``와 ``Offset`` 값을 대입을 통해 직접 변경은 가능하지만 되도록이면 직접 값을 써넣는 일은 피하시길 권장합니다.
 
 <br/>
 아래와 같은 함수들도 사용할 수 있습니다.<br/>
@@ -395,7 +399,7 @@ CGDK.buffer의 멤버변수는 buffer, m_offset, m_count 3개의 멤버 변수�
 <br/>
 
 ## CGD.buffer 복사하기<br/>
-CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.buffer 자체는 통채로 복사가 됩니다. 하지만 얕은 복사가 되죠.
+``CGDK.buffer``의 기본적으로 구조체이므로 그냥 대입을 하면 ``CGD.buffer`` 자체는 통채로 복사가 됩니다. 하지만 얕은 복사가 되죠.
 따라서 이렇게 복사를 하면
    ``` C#
    var buf = new CGDK.buffer(256);
@@ -414,10 +418,10 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
    x2 = buf2.Extract<sbyte>(); // 20이 됩니다. 
    ```
    기본적인 버퍼의 복사는 '얇은 복사'를 수행하므로<br/>
-   m_buffer, m_Offset, m_Count 값은 복사가 되지만 버퍼의 내용 자체는 복사되지 않고 공유됩니다. <br/>
-   원본 CGDK.buffer의 Offset과 Count는 변경하지 않고 값을 읽고 싶을 경우 GetFront<T>()보다 얇은 복사로 임시 버퍼를 생성해 Extract<T>()하는 방식이 많이 사용됩니다. <br/>
+   ``m_buffer``, ``m_Offset``, ``m_Count`` 값은 복사가 되지만 버퍼의 내용 자체는 복사되지 않고 공유됩니다. <br/>
+   원본 ``CGDK.buffer``의 ``Offset``과 ``Count``는 변경하지 않고 값을 읽고 싶을 경우 ``GetFront<T>()``보다 얇은 복사로 임시 버퍼를 생성해 ``Extract<T>()``하는 방식이 많이 사용됩니다. <br/>
  <br/>
-   만약에 깊은 복사를 원하면 멤버함수인 Clone()을 하십시요. <br/>
+   만약에 깊은 복사를 원하면 멤버함수인 ``Clone()``을 하십시요. <br/>
 
    ``` C#
    var buf = new CGDK.buffer(new byte[256]);
@@ -433,8 +437,8 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
 
 ## CGD.buffer 연산자<br/>
 ### 1. Offset을 주어 얇은 복사하기
--  '+ CGDK.Offset()'를 사용하면 Offset을 미리 주어 얇은 복사를 수행할 수 있습니다.<br>
-이 Offset을 주는 얇은 복사는 매우 많이 사용됩니다.<br>
+-  ``+ CGDK.Offset()``를 사용하면 ``Offset``을 미리 주어 얇은 복사를 수행할 수 있습니다.<br>
+이 ``Offset``을 주는 얇은 복사는 매우 많이 사용됩니다.<br>
 
    ``` C#
    // buf1을 Offset 8만큼 주어서 얇은 복사를 한다.
@@ -443,7 +447,7 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
    ```
 
 ### 2. 크기를 조정해 얇은 복사하기
--  '+ CGDK.Size()'를 사용하면 Size를 늘리거나 줄여서 얇은 복사를 한다.
+-  ``+ CGDK.Size()``를 사용하면 ``Size``를 늘리거나 줄여서 얇은 복사를 한다.
 
    ``` C#
    // buf1을 Size를 8만큼 줄여서 얇은 복사를 한다.
@@ -452,7 +456,7 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
    ```
 
 ### 3. Offset을 대입한  얇은 복사하기
-- '* CGDK.Offset()'으로 Offset을 앗사리 특정 값으로 대입해 얇은 복사를 수행할 수 있습니다.
+- ``* CGDK.Offset()``으로 ``Offset``을 앗사리 특정 값으로 대입해 얇은 복사를 수행할 수 있습니다.
    ``` C#
    // buf1을 Offset 8만큼 주어서 얇은 복사한다.
    // 즉, buf2.Offset = 8, buf2.Count = buf1.Count
@@ -460,7 +464,7 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
    ```
 
 ### 4. Size를 대입한 얇은 복사하기
-- '^ CGDK.Size()'로 Offset을 앗사리 특정 값으로 대입해 얇은 복사를 수행할 수 있습니다.
+- ``^ CGDK.Size()``로 ``Offset``을 앗사리 특정 값으로 대입해 얇은 복사를 수행할 수 있습니다.
    ``` C#
    // buf1을 Offset 8 만큼 주어서 얇은 복사를 한다.
    // 즉, buf2.Offset = buf1.Offset, buf2.Count = 8
@@ -468,8 +472,8 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
    ```
 
 ### 5. Offset과 Size 모두 변경해 얇은 복사하기
-- '^ + tuple'로 Offset,Count 모두를 한번에 대입한 값으로 얇은 복사를 수행할 수 있습니다.
-그냥 m_buffer만 복사하는 격입니다.
+- ``^ + tuple``로 ``Offset``,``Count`` 모두를 한번에 대입한 값으로 얇은 복사를 수행할 수 있습니다.
+그냥 ``m_buffer``만 복사하는 격입니다.
    ``` C#
    // buf1을 Offset 4, Count는 8로 설정한다.
    // 즉, buf2.Offset = 4, buf2.Count = 8
@@ -478,8 +482,8 @@ CGDK.buffer의 기본적으로 구조체이므로 그냥 대입을 하면 CGD.bu
 <br/>
 
 ## 지원 가능<br/>
-* C# .NET core<br/>
-* C# .NET framework 버전을 설치해야 합니다. (다만 Roslyn과 Source Generator)는 지원하지 않습니다)<br/>
+* ``C# .NET core``<br/>
+* ``C# .NET framework`` 버전을 설치해야 합니다. (다만 ``Roslyn``과 ``Source Generator``)는 지원하지 않습니다)<br/>
 * unity 3D(c#) 지원<br/>
 
 <br/>

--- a/C#/projects/CGDK.buffer.Generator/CGDKbuffer.Generator.cs
+++ b/C#/projects/CGDK.buffer.Generator/CGDKbuffer.Generator.cs
@@ -418,12 +418,12 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 	private static  void GetClassDeclarationInfo(ref List<OBJECT_INFO> _output, GeneratorExecutionContext _context, in SyntaxTree _syntax_tree, in SemanticModel _semantic_model)
 	{
 		// 1) find class declation
-		foreach (var iter in _syntax_tree.GetRoot().DescendantNodes() // (1) 모든 자손들 노드 중에
-							.Where(node => node.IsKind(SyntaxKind.ClassDeclaration)) // (2) Node Kind가 'class 선언'인 것만 골라서
-							.Cast<ClassDeclarationSyntax>() // (4) ClassDeclarationSyntax 캐스팅해서
-							.Where(x => (x.AttributeLists // (3) Attribute 중에 "CGDK.Attribute.Serializable"을 가진 것만 골라낸다!
+		foreach (var iter in _syntax_tree.GetRoot().DescendantNodes() // 1. 모든 자손들 노드 중에
+							.Where(node => node.IsKind(SyntaxKind.ClassDeclaration)) // 2. Node Kind가 'class 선언'인 것만 골라서
+							.Cast<ClassDeclarationSyntax>() // 3. ClassDeclarationSyntax 캐스팅해서
+							.Where(x => (x.AttributeLists // 4. Attribute 중에 "CGDK.Attribute.Serializable"을 가진 것만 골라낸다!
 								.Where(x => x.ToString() == "[CGDK.Attribute.Serializable]").Any()))
-							.ToList()) // (5) 리스트로~
+							.ToList()) // 5. 리스트로~
 		{
 			// 2) alloc OBJECT_INFO
 			var class_info = new OBJECT_INFO();
@@ -471,19 +471,19 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 				continue;
 			}
 
-			// 5) make full typ name string and identifier name
+			// 4) make full typ name string and identifier name
 			class_info.type_name = type_info.ToString();
 			class_info.identifier = iter.Identifier.ToString() + iter.GetHashCode().ToString();
 
-			// 6) make 'member_node_info' list
+			// 5) make 'member_node_info' list
 			class_info.list_member_node_info = [];
 
-			// 7) gatter members info
+			// 6) gatter members info
 			foreach (var member in type_info.GetMembers()
-								.Where(x => x.Kind == SymbolKind.Field || x.Kind == SymbolKind.Property) // 1) Field(변수) 혹은 Property 만 얻어서
-								.Where(x => (x.GetAttributes() // (2) Attribute 중에 "CGDK.Field"을 가진 것만 골라낸다!
+								.Where(x => x.Kind == SymbolKind.Field || x.Kind == SymbolKind.Property) // 1. Field(변수) 혹은 Property 만 얻어서
+								.Where(x => (x.GetAttributes() // 2. Attribute 중에 "CGDK.Field"을 가진 것만 골라낸다!
 									.Where(y => y.ToString() == "CGDK.Attribute.Field(true)").Any()))
-								.ToList()) // (3) 리스트로~
+								.ToList()) // 3. 리스트로~
 			{
 				// check)
 				if (member.DeclaredAccessibility != Accessibility.Public)
@@ -522,7 +522,7 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 				class_info.list_member_node_info.Add(member_node_info);
 			}
 
-			// 8) add struct info
+			// 7) add struct info
 			_output.Add(class_info);
 		}
 	}
@@ -548,12 +548,12 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 	private static void GetStructDeclarationInfo(ref List<OBJECT_INFO> _output, GeneratorExecutionContext _context, in SyntaxTree _syntax_tree, in SemanticModel _semantic_model)
 	{
 		// 1) find struct class declation
-		foreach (var iter in _syntax_tree.GetRoot().DescendantNodes() // (1) 모든 자손들 노드 중에
-							.Where(node => node.IsKind(SyntaxKind.StructDeclaration)) // (2) Node Kind가 'struct 선언'인 것만 골라서
-							.Cast<StructDeclarationSyntax>() // (4) StructDeclarationSyntax로 캐스팅해서
-							.Where(x => (x as StructDeclarationSyntax)?.AttributeLists // (3) Attribute 중에 "CGDK.Attribute.Serializable"을 가진 것만 골라낸다!
+		foreach (var iter in _syntax_tree.GetRoot().DescendantNodes() // 1. 모든 자손들 노드 중에
+							.Where(node => node.IsKind(SyntaxKind.StructDeclaration)) // 2. Node Kind가 'struct 선언'인 것만 골라서
+							.Cast<StructDeclarationSyntax>() // 3. StructDeclarationSyntax로 캐스팅해서
+							.Where(x => (x as StructDeclarationSyntax)?.AttributeLists // 4. Attribute 중에 "CGDK.Attribute.Serializable"을 가진 것만 골라낸다!
 								.Where(x => x.ToString() == "[CGDK.Attribute.Serializable]").Any() ?? false)
-							.ToList()) // (5) List로...
+							.ToList()) // 5. List로...
 		{
 			// 2) alloc OBJECT_INFO
 			var struct_info = new OBJECT_INFO();
@@ -605,10 +605,10 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 
 			// 6) gatter members info
 			foreach (var member in type_info.GetMembers()
-								.Where(x => x.Kind == SymbolKind.Field || x.Kind == SymbolKind.Property) // 1) Field(변수) 혹은 Property 만 얻어서
-								.Where(x => !(x.GetAttributes() // (2) Attribute 중에 "CGDK.Field"을 가진 것만 골라낸다!
+								.Where(x => x.Kind == SymbolKind.Field || x.Kind == SymbolKind.Property) // 1. Field(변수) 혹은 Property 만 얻어서
+								.Where(x => !(x.GetAttributes() // 2. Attribute 중에 "CGDK.Field"을 가진 것만 골라낸다!
 									.Where(y => y.ToString() == "CGDK.Attribute.Field(false)").Any()))
-								.ToList()) // (3) 리스트로~
+								.ToList()) // 3. 리스트로~
 			{
 				// check)
 				if (member.DeclaredAccessibility != Accessibility.Public)

--- a/C#/projects/CGDK.buffer.Generator/CGDKbuffer.Generator.cs
+++ b/C#/projects/CGDK.buffer.Generator/CGDKbuffer.Generator.cs
@@ -126,7 +126,7 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 		{
 			// - get symantic model
 			var symantic_model = context.Compilation.GetSemanticModel(syntaxTree);
-
+			 
 			// - extract class declaration info
 			GetClassDeclarationInfo(ref list_class_declaration, context, syntaxTree, symantic_model);
 
@@ -549,7 +549,7 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 	{
 		// 1) find struct class declation
 		foreach (var iter in _syntax_tree.GetRoot().DescendantNodes() // (1) 모든 자손들 노드 중에
-							.Where(node => node.IsKind(SyntaxKind.StructDeclaration)) // (2) Node Kind가 'class 선언'인 것만 골라서
+							.Where(node => node.IsKind(SyntaxKind.StructDeclaration)) // (2) Node Kind가 'struct 선언'인 것만 골라서
 							.Cast<StructDeclarationSyntax>() // (4) StructDeclarationSyntax로 캐스팅해서
 							.Where(x => (x as StructDeclarationSyntax)?.AttributeLists // (3) Attribute 중에 "CGDK.Attribute.Serializable"을 가진 것만 골라낸다!
 								.Where(x => x.ToString() == "[CGDK.Attribute.Serializable]").Any() ?? false)
@@ -567,10 +567,6 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 			// check) throw exception if type_info is null!
 			if (type_info == null)
 				throw new Exception();
-
-			// check) skip 'static' member
-			if (type_info.IsStatic == true)
-				continue;
 
 			// check) must be 'public' accessbility
 			if (type_info.DeclaredAccessibility != Accessibility.Public)
@@ -596,6 +592,8 @@ public partial class CGDKbufferGenerator : ISourceGenerator
 				null,
 				type_info.Locations.FirstOrDefault<Location>(),
 				null));
+
+				continue;
 			}
 
 			// 4) make full typ name string and identifier name

--- a/C#/projects/CGDK.buffer.NET.framework.sln
+++ b/C#/projects/CGDK.buffer.NET.framework.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CGDK.buffer.NET.framework", "buffer.NET.framework\CGDK.buffer.NET.framework.csproj", "{7D5B6392-B36F-4B81-B229-EE314090CD8C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CGDK.buffer.Generator", "CGDK.buffer.Generator\CGDK.buffer.Generator.csproj", "{CE6FD716-209E-495D-B5DE-60B986170B05}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,14 +21,6 @@ Global
 		{7D5B6392-B36F-4B81-B229-EE314090CD8C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7D5B6392-B36F-4B81-B229-EE314090CD8C}.Release|x64.ActiveCfg = Release|x64
 		{7D5B6392-B36F-4B81-B229-EE314090CD8C}.Release|x64.Build.0 = Release|x64
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Debug|x64.Build.0 = Debug|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Release|x64.ActiveCfg = Release|Any CPU
-		{CE6FD716-209E-495D-B5DE-60B986170B05}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/C#/projects/buffer.NET.core/CGDKbuffer.NET.cs
+++ b/C#/projects/buffer.NET.core/CGDKbuffer.NET.cs
@@ -750,6 +750,7 @@ namespace CGDK
 		// Append (serialize)
 		//
 		//	1) void Append<T>(T)
+		//	1) void Append<T>()
 		//  2) void Append(byte[], int, int)
 		//	3) void AppendText(string)
 		//	4) void AppendText(ICollection<string>)
@@ -819,6 +820,48 @@ namespace CGDK
 				BufferSerializer.Get<T>.instance.ProcessAppend(ref ptr_now, ptr_bound, _value);
 
 				// 3) update offset & count
+				this.m_count += (int)(ptr_now - ptr_pre);
+			}
+		}
+
+		/// <summary>
+		/// 데이터를 직렬화해 버퍼에 써넣는다.
+		/// </summary>
+		/// <typeparam name="T">직렬화할 대상 클래스</typeparam> 
+		/// <remarks>
+		/// 빈 데이터를 직렬화해 버퍼에 써 넣는다.<br/>
+		/// </remarks>
+		/// <see cref="AppendSkip(in int)"/>
+		/// <see cref="Append(in byte[], in int, in int)"/>
+		/// <see cref="Append{K, V}(in Dictionary{K, V})"/>
+		/// <see cref="AppendText(in string)"/>
+		/// <see cref="AppendText(string[])"/>
+		/// <see cref="Extract{T}"/>
+		/// <see cref="GetSizeOf{T}(in T)"/>
+		public unsafe void	Append<T>() where T: new()
+		{
+			// check) 
+			Debug.Assert(this.m_buffer != null);
+
+		#if _USE_BOUND_CHECK
+			// check)
+			if(this.m_buffer == null)
+				throw new System.NullReferenceException("buffer is not allocated");
+		#endif
+			// 1) 기본형을 얻는다.
+			var value = new T();
+
+			fixed (byte* ptr = this.m_buffer)
+			{
+				// 2) calculare ptr_now & ptr_bound
+				var ptr_pre = (long)ptr + this.m_offset + this.m_count;
+				var ptr_now = ptr_pre;
+				var ptr_bound = (long)ptr + this.m_buffer.Length;
+
+				// 3) append
+				BufferSerializer.Get<T>.instance.ProcessAppend(ref ptr_now, ptr_bound, value);
+
+				// 4) update offset & count
 				this.m_count += (int)(ptr_now - ptr_pre);
 			}
 		}

--- a/C#/projects/buffer.NET.core/CGDKbuffer.NET.cs
+++ b/C#/projects/buffer.NET.core/CGDKbuffer.NET.cs
@@ -1092,7 +1092,7 @@ namespace CGDK
 				// 3) extract
 				var temp = BufferSerializer.Get<T>.instance.ProcessExtract(ref ptr_now, ref count);
 
-				// 3) update offset & count
+				// 4) update offset & count
 				this.m_offset = (int)(ptr_now - (long)ptr);
 				this.m_count = count;
 
@@ -1127,7 +1127,7 @@ namespace CGDK
             if (this.m_count > _bytes)
                 throw new CGDK.Exception.Serialize(_bytes, "[CGDK.buffer] buffer size is short");
 
-            // 2) update offset & count
+            // 1) update offset & count
             this.m_offset += _bytes;
             this.m_count -= _bytes;
         }
@@ -2076,7 +2076,7 @@ namespace CGDK
 					// check)
 					Debug.Assert(_ptr + sizeof(Int64) + _object.Count<= _ptr_bound);
 
-					// 1) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+					// 2) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 					Unsafe.AsRef<Int64>((void*)_ptr) = _object.Count;
 					_ptr += sizeof(Int64);
 
@@ -2087,7 +2087,7 @@ namespace CGDK
 					// 3) 복사해 붙인다.
 					System.Buffer.MemoryCopy(buf_source, (void*)_ptr, _ptr_bound - _ptr, _object.Count); // NULL 포함 복사
 
-					// 6) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
+					// 4) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
 					_ptr += _object.Count;
 				}
 			}
@@ -2183,7 +2183,7 @@ namespace CGDK
 					// check)
 					Debug.Assert(_ptr + sizeof(Int64) + temp_buf.Count <= _ptr_bound);
 
-					// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+					// - [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 					Unsafe.AsRef<Int64>((void*)_ptr) = temp_buf.Count;
 					_ptr += sizeof(Int64);
 
@@ -2191,10 +2191,10 @@ namespace CGDK
 					if (temp_buf.Count == 0)
 						return;
 
-					// 4) 복사해 붙인다.
+					// - 복사해 붙인다.
 					System.Buffer.MemoryCopy(buf_source, (void*)_ptr, _ptr_bound - _ptr, temp_buf.Count); // NULL 포함 복사
 
-					// 5) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
+					// - [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
 					_ptr += temp_buf.Count;
 				}
 			}
@@ -2270,23 +2270,23 @@ namespace CGDK
 					return;
 				}
 
-				// 2) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
+				// 1) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
 				var string_length_bytes = _object.Length * sizeof(char) + sizeof(char);
 
 				// check)
 				Debug.Assert(_ptr + sizeof(Int32) + string_length_bytes <= _ptr_bound);
 
-				// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+				// 2) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length + 1;
 
-				// 4) add size
+				// 3) add size
 				_ptr += sizeof(Int32);
 
-				// 5) [문자열]을 복사해 넣는다.
+				// 4) [문자열]을 복사해 넣는다.
 				fixed (char* str = (string?)_object)
 					System.Buffer.MemoryCopy(str, (void*)_ptr, _ptr_bound - _ptr, string_length_bytes); // NULL 포함 복사
 
-				// 6) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
+				// 5) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
 				_ptr += string_length_bytes;
 			}
 			public static unsafe string? XProcessExtract(ref long _ptr, ref int _count)
@@ -2392,13 +2392,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				var iter_item = ((IEnumerable<V>)_object).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2488,13 +2488,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				fixed(void* ptr_src = _object)
 				{
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr,  _object.Length * sizeof(V)); // NULL 포함 복사
@@ -2658,7 +2658,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_list != null);
 
-				// 2) 'items'
+				// 3) 'items'
 				var iter_item = obj_list.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2729,7 +2729,7 @@ namespace CGDK
 				// 3) create list
 				var obj_array = new V[item_count];
 
-				// 5) read all items
+				// 4) read all items
 				for (int i = 0; i < item_count; ++i)
 				{
 					// - get item
@@ -2760,7 +2760,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_array != null);
 
-				// 2) add size of 'items'
+				// 3) add size of 'items'
 				var iter_item = ((IEnumerable<V>)obj_array).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2805,7 +2805,7 @@ namespace CGDK
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr, obj_array.Length * sizeof(V)); // NULL 포함 복사
 				}
 
-				// 4) add ptr
+				// 5) add ptr
 				_ptr += sizeof(V) * obj_array.Length;
 			}
 			public unsafe object? ProcessExtract(ref long _ptr, ref int _count)
@@ -4811,7 +4811,7 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 1) build by type
+				// 2) build by type
 				if (type.IsPrimitive)
 					result = BuildSerailizer_Primitive(type);
 				else if (type.IsEnum)
@@ -5054,7 +5054,7 @@ namespace CGDK
 			}
 			private static object? BuildSerializer_Dictionary_typed<T>()
 			{
-				// 2) get argument type
+				// 1) get argument type
 				var types = typeof(T).GetGenericArguments();
 				var type_key = types[0];
 				var type_value = types[1];
@@ -5752,16 +5752,16 @@ namespace CGDK
 				if (IsSerializableType(_type) == false)
 					throw new System.NullReferenceException("class is not CGDK.serializable");
 
-				// 2) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
+				// 1) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
 				if (_type.BaseType != null && _type.BaseType.BaseType != null)
 				{
 					BuildSerializer_Class(_type.BaseType, ref _list_member_serialization_info);
 				}
 
-				// 3) member변수들을 얻는다.
+				// 2) member변수들을 얻는다.
 				var temp_field = _type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-				// 4) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
+				// 3) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
 				foreach (var iter in temp_field)
 				{
 					// check)
@@ -5830,15 +5830,15 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 존재하지 않으면 새로 만든다.
+					// 3) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -5866,19 +5866,19 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(Dictionary<K, V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is IBase<Dictionary<K, V>>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 먼저 시돈
@@ -5893,7 +5893,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = Unsafe.As<IBase<Dictionary<K, V>>?>(result);
 
 				// check)
@@ -5907,19 +5907,19 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(List<V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is SerializerList_typed<V>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - build
@@ -5934,7 +5934,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = Unsafe.As<IBase<List<V>>?>(result);
 
 				// check)
@@ -5953,7 +5953,7 @@ namespace CGDK
 					// 1) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(_type, out result);
 
-					// 3) 존재하지 않으면 새로 만든다.
+					// 2) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -5976,15 +5976,15 @@ namespace CGDK
 				if (_serializer == null)
 					return;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out object? result);
 
-					// 4) 존재하지 않으면 추가 존재하면 교체
+					// 3) 존재하지 않으면 추가 존재하면 교체
 					if (is_exist == false)
 						dictionary_serializer.Add(type, _serializer);
 					else
@@ -5997,15 +5997,15 @@ namespace CGDK
 				if (_serializer == null)
 					return;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer_object)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(type, out object? result);
 
-					// 4) 존재하지 않으면 추가 존재하면 교체
+					// 3) 존재하지 않으면 추가 존재하면 교체
 					if (is_exist == false)
 						dictionary_serializer_object.Add(type, _serializer);
 					else

--- a/C#/projects/buffer.NET.framework/CGDK.buffer.NET.framework.cs
+++ b/C#/projects/buffer.NET.framework/CGDK.buffer.NET.framework.cs
@@ -1545,7 +1545,7 @@ namespace CGDK
 					// check)
 					Debug.Assert(_ptr + sizeof(Int64) + _object.Count<= _ptr_bound);
 
-					// 1) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+					// 2) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 					*(Int64*)_ptr = _object.Count;
 					_ptr += sizeof(Int64);
 
@@ -1556,7 +1556,7 @@ namespace CGDK
 					// 3) 복사해 붙인다.
 					System.Buffer.MemoryCopy(buf_source, (void*)_ptr, _ptr_bound - _ptr, _object.Count); // NULL 포함 복사
 
-					// 6) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
+					// 4) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
 					_ptr += _object.Count;
 				}
 			}
@@ -1628,7 +1628,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(temp.Count >= 0);
 
-				// 3) get buffer
+				// 2) get buffer
 				var buf = temp.Array;
 
 				// check)
@@ -1640,13 +1640,13 @@ namespace CGDK
 					return;
 				}
 
-				// 4) write to buffer
+				// 3) write to buffer
 				fixed (byte* buf_source = buf)
 				{
 					// check)
 					Debug.Assert(_ptr + sizeof(Int64) + temp.Count <= _ptr_bound);
 
-					// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+					// 4) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 					*(Int64*)_ptr = temp.Count;
 					_ptr += sizeof(Int64);
 
@@ -1654,10 +1654,10 @@ namespace CGDK
 					if (temp.Count == 0)
 						return;
 
-					// 4) 복사해 붙인다.
+					// 5) 복사해 붙인다.
 					System.Buffer.MemoryCopy(buf_source, (void*)_ptr, _ptr_bound - _ptr, temp.Count); // NULL 포함 복사
 
-					// 5) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
+					// 6) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
 					_ptr += temp.Count;
 				}
 			}
@@ -1730,23 +1730,23 @@ namespace CGDK
 					return;
 				}
 
-				// 2) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
+				// 1) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
 				var string_length_bytes = _object.Length * sizeof(char) + sizeof(char);
 
 				// check)
 				Debug.Assert(_ptr + sizeof(Int32) + string_length_bytes <= _ptr_bound);
 
-				// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+				// 2) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 				*(Int32*)_ptr = _object.Length + 1;
 
-				// 4) add size
+				// 3) add size
 				_ptr += sizeof(Int32);
 
-				// 5) [문자열]을 복사해 넣는다.
+				// 4) [문자열]을 복사해 넣는다.
 				fixed (char* str = (string)_object)
 					System.Buffer.MemoryCopy(str, (void*)_ptr, _ptr_bound - _ptr, string_length_bytes); // NULL 포함 복사
 
-				// 6) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
+				// 5) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
 				_ptr += string_length_bytes;
 			}
 			public static unsafe string XProcessExtract(ref long _ptr, ref int _count)
@@ -1852,13 +1852,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				*(Int32*)_ptr = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				var iter_item = ((IEnumerable<V>)_object).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -1948,13 +1948,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				*(Int32*)_ptr = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				fixed(void* ptr_src = _object)
 				{
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr,  _object.Length * sizeof(V)); // NULL 포함 복사
@@ -2118,7 +2118,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_list != null);
 
-				// 2) 'items'
+				// 3) 'items'
 				var iter_item = obj_list.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2189,7 +2189,7 @@ namespace CGDK
 				// 3) create list
 				var obj_array = new V[item_count];
 
-				// 5) read all items
+				// 4) read all items
 				for (int i = 0; i < item_count; ++i)
 				{
 					// - get item
@@ -2220,7 +2220,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_array != null);
 
-				// 2) add size of 'items'
+				// 3) add size of 'items'
 				var iter_item = ((IEnumerable<V>)obj_array).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2265,7 +2265,7 @@ namespace CGDK
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr, obj_array.Length * sizeof(V)); // NULL 포함 복사
 				}
 
-				// 4) add ptr
+				// 5) add ptr
 				_ptr += sizeof(V) * obj_array.Length;
 			}
 			public unsafe object ProcessExtract(ref long _ptr, ref int _count)
@@ -2461,16 +2461,16 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write -1 
+				// 1) write -1 
 				*(Int32*)_ptr = _object.Count;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
 				// check)
 				Debug.Assert(_object != null);
 
-				// 4) write items
+				// 3) write items
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2536,10 +2536,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = _object.GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					// - add size of 'key' & 'value'
@@ -2566,7 +2566,7 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write -1 
+				// 1) write -1 
 				*(Int32*)_ptr = _object.Count;
 
 				// check)
@@ -2576,10 +2576,10 @@ namespace CGDK
 				if((_ptr + sizeof(Int32) + (sizeof(K) + sizeof(V)) * _object.Count) > _ptr_bound)
 					throw new System.IndexOutOfRangeException("buffer overflow");
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write items
+				// 3) write items
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2907,10 +2907,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = ((Dictionary<K, V>)_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3059,10 +3059,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = ((IDictionary<K,V>)_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3181,10 +3181,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = ((IDictionary<X,Y>)_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += _serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3368,13 +3368,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				*(Int32*)_ptr = _object.Count;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -3404,13 +3404,13 @@ namespace CGDK
 				// 3) create list
 				var obj = new List<V>();
 
-				// 5) sub count
+				// 4) sub count
 				_count -= sizeof(V) * item_count;
 
-				// 6) set capacity
+				// 5) set capacity
 				obj.Capacity = item_count;
 
-				// 7) write items
+				// 6) write items
 				while (item_count > 0)
 				{
 					// - add item
@@ -3699,13 +3699,13 @@ namespace CGDK
 				// 3) create list
 				var obj = new List<V>();
 
-				// 5) sub count
+				// 4) sub count
 				_count -= sizeof(V) * item_count;
 
-				// 6) set capacity
+				// 5) set capacity
 				obj.Capacity = item_count;
 
-				// 7) read all items
+				// 6) read all items
 				while (item_count > 0)
 				{
 					// - add item
@@ -4259,7 +4259,7 @@ namespace CGDK
 				// declare) 
 				object result = null;
 
-				// 1) build by type
+				// 2) build by type
 				if (type.IsPrimitive)
 					result = BuildSerailizer_Primitive(type);
 				else if (type.IsEnum)
@@ -4474,7 +4474,7 @@ namespace CGDK
 			}
 			private static object BuildSerializer_Dictionary_typed<T>()
 			{
-				// 2) get argument type
+				// 1) get argument type
 				var types = typeof(T).GetGenericArguments();
 				var type_key = types[0];
 				var type_value = types[1];
@@ -5172,16 +5172,16 @@ namespace CGDK
 				if (IsSerializableType(_type) == false)
 					throw new System.NullReferenceException("class is not CGDK.serializable");
 
-				// 2) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
+				// 1) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
 				if (_type.BaseType != null && _type.BaseType.BaseType != null)
 				{
 					BuildSerializer_Class(_type.BaseType, ref _list_member_serialization_info);
 				}
 
-				// 3) member변수들을 얻는다.
+				// 2) member변수들을 얻는다.
 				var temp_field = _type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-				// 4) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
+				// 3) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
 				foreach (var iter in temp_field)
 				{
 					// check)
@@ -5250,15 +5250,15 @@ namespace CGDK
 				// declare) 
 				object result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 존재하지 않으면 새로 만든다.
+					// 3) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -5286,19 +5286,19 @@ namespace CGDK
 				// declare) 
 				object result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(Dictionary<K, V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is IBase<Dictionary<K, V>>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 먼저 시돈
@@ -5313,7 +5313,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = (IBase<Dictionary<K,V>>)result;
 
 				// check)
@@ -5327,19 +5327,19 @@ namespace CGDK
 				// declare) 
 				object result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(List<V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is SerializerList_typed<V>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - build
@@ -5354,7 +5354,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = (IBase<List<V>>)result;
 
 				// check)
@@ -5373,7 +5373,7 @@ namespace CGDK
 					// 1) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(_type, out result);
 
-					// 3) 존재하지 않으면 새로 만든다.
+					// 2) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -5396,15 +5396,15 @@ namespace CGDK
 				if (_serializer == null)
 					return;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out object result);
 
-					// 4) 존재하지 않으면 추가 존재하면 교체
+					// 3) 존재하지 않으면 추가 존재하면 교체
 					if (is_exist == false)
 						dictionary_serializer.Add(type, _serializer);
 					else
@@ -5417,15 +5417,15 @@ namespace CGDK
 				if (_serializer == null)
 					return;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer_object)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(type, out object result);
 
-					// 4) 존재하지 않으면 추가 존재하면 교체
+					// 3) 존재하지 않으면 추가 존재하면 교체
 					if (is_exist == false)
 						dictionary_serializer_object.Add(type, _serializer);
 					else

--- a/C#/projects/buffer.NET/CGDKbuffer.NET.cs
+++ b/C#/projects/buffer.NET/CGDKbuffer.NET.cs
@@ -1111,7 +1111,7 @@ namespace CGDK
 				// 3) extract
 				var temp = BufferSerializer.Get<T>.instance.ProcessExtract(ref ptr_now, ref count);
 
-				// 3) update offset & count
+				// 4) update offset & count
 				this.m_offset = (int)(ptr_now - (long)ptr);
 				this.m_count = count;
 
@@ -1489,7 +1489,7 @@ namespace CGDK
 		{
 			public unsafe void ProcessAppend(ref long _ptr, long _ptr_bound, Vector2 _object)
 			{
-				// 2) write
+				// 1) write
 				*(float*)_ptr = _object.X; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Y; _ptr += sizeof(float);
 			}
@@ -1501,7 +1501,7 @@ namespace CGDK
 						*(float*)(_ptr +  4)
 					);
 
-				// 3) update count
+				// 2) update count
 				_ptr += sizeof(float) * 2;
 				_count -= sizeof(float) * 2;
 
@@ -1605,7 +1605,7 @@ namespace CGDK
 		{
 			public unsafe void ProcessAppend(ref long _ptr, long _ptr_bound, Vector4 _object)
 			{
-				// 2) write
+				// 1) write
 				*(float*)_ptr = _object.X; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Y; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Z; _ptr += sizeof(float);
@@ -1669,7 +1669,7 @@ namespace CGDK
 		{
 			public unsafe void ProcessAppend(ref long _ptr, long _ptr_bound, Plane _object)
 			{
-				// 2) write
+				// 1) write
 				*(float*)_ptr = _object.Normal.X; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Normal.Y; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Normal.Z; _ptr += sizeof(float);
@@ -1711,6 +1711,7 @@ namespace CGDK
 			}
 			public unsafe object? ProcessExtract(ref long _ptr, ref int _count)
 			{
+				// 1) make
 				var temp = new Plane(
 						*(float*)(_ptr + 0),
 						*(float*)(_ptr + 4),
@@ -1731,7 +1732,7 @@ namespace CGDK
 		{
 			public unsafe void ProcessAppend(ref long _ptr, long _ptr_bound, Quaternion _object)
 			{
-				// 2) write
+				// 1) write
 				*(float*)_ptr = _object.X; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Y; _ptr += sizeof(float);
 				*(float*)_ptr = _object.Z; _ptr += sizeof(float);
@@ -2203,7 +2204,7 @@ namespace CGDK
 					// check)
 					Debug.Assert(_ptr + sizeof(Int64) + temp_buf.Count <= _ptr_bound);
 
-					// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+					// - [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 					Unsafe.AsRef<Int64>((void*)_ptr) = temp_buf.Count;
 					_ptr += sizeof(Int64);
 
@@ -2211,10 +2212,10 @@ namespace CGDK
 					if (temp_buf.Count == 0)
 						return;
 
-					// 4) 복사해 붙인다.
+					// - 복사해 붙인다.
 					System.Buffer.MemoryCopy(buf_source, (void*)_ptr, _ptr_bound - _ptr, temp_buf.Count); // NULL 포함 복사
 
-					// 5) [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
+					// - [버퍼_길이]를 더해준다. (NULL문자열의 길이까지 포함한다.)
 					_ptr += temp_buf.Count;
 				}
 			}
@@ -2290,23 +2291,23 @@ namespace CGDK
 					return;
 				}
 
-				// 2) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
+				// 1) [문자열]을 [문자배열]로 변경하고 길이를 구한다.(NULL 포함 크기)
 				var string_length_bytes = _object.Length * sizeof(char) + sizeof(char);
 
 				// check)
 				Debug.Assert(_ptr + sizeof(Int32) + string_length_bytes <= _ptr_bound);
 
-				// 3) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
+				// 2) [문자열 길이]를 써넣는다. (NULL을 포함한 문자열의 길이)
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length + 1;
 
-				// 4) add size
+				// 3) add size
 				_ptr += sizeof(Int32);
 
-				// 5) [문자열]을 복사해 넣는다.
+				// 4) [문자열]을 복사해 넣는다.
 				fixed (char* str = (string?)_object)
 					System.Buffer.MemoryCopy(str, (void*)_ptr, _ptr_bound - _ptr, string_length_bytes); // NULL 포함 복사
 
-				// 6) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
+				// 5) 써넣은 bytes만큼 더해준다. (NULL문자열의 길이까지 포함)
 				_ptr += string_length_bytes;
 			}
 			public static unsafe string? XProcessExtract(ref long _ptr, ref int _count)
@@ -2412,13 +2413,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				var iter_item = ((IEnumerable<V>)_object).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2508,13 +2509,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Length;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				fixed(void* ptr_src = _object)
 				{
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr,  _object.Length * sizeof(V)); // NULL 포함 복사
@@ -2678,7 +2679,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_list != null);
 
-				// 2) 'items'
+				// 3) 'items'
 				var iter_item = obj_list.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2749,7 +2750,7 @@ namespace CGDK
 				// 3) create list
 				var obj_array = new V[item_count];
 
-				// 5) read all items
+				// 4) read all items
 				for (int i = 0; i < item_count; ++i)
 				{
 					// - get item
@@ -2780,7 +2781,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_array != null);
 
-				// 2) add size of 'items'
+				// 3) add size of 'items'
 				var iter_item = ((IEnumerable<V>)obj_array).GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -2825,7 +2826,7 @@ namespace CGDK
 					System.Buffer.MemoryCopy(ptr_src, (void*)_ptr, _ptr_bound - _ptr, obj_array.Length * sizeof(V)); // NULL 포함 복사
 				}
 
-				// 4) add ptr
+				// 5) add ptr
 				_ptr += sizeof(V) * obj_array.Length;
 			}
 			public unsafe object? ProcessExtract(ref long _ptr, ref int _count)
@@ -3021,16 +3022,16 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write -1 
+				// 1) write -1 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Count;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
 				// check)
 				Debug.Assert(_object != null);
 
-				// 4) write items
+				// 3) write items
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -3099,10 +3100,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = _object.GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					// - add size of 'key' & 'value'
@@ -3129,7 +3130,7 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write -1 
+				// 1) write -1 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Count;
 
 				// check)
@@ -3139,10 +3140,10 @@ namespace CGDK
 				if((_ptr + sizeof(Int32) + (sizeof(K) + sizeof(V)) * _object.Count) > _ptr_bound)
 					throw new System.IndexOutOfRangeException("buffer overflow");
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write items
+				// 3) write items
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -3476,10 +3477,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = Unsafe.As<Dictionary<K, V>>(_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3593,10 +3594,10 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj != null);
 
-				// 5) Ensure Capacity
+				// 4) Ensure Capacity
 				obj.EnsureCapacity(item_count);
 
-				// 4) write items
+				// 5) write items
 				while (item_count > 0)
 				{
 					// - get key & value
@@ -3631,10 +3632,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = Unsafe.As<IDictionary<K,V>>(_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3753,10 +3754,10 @@ namespace CGDK
 				if (_object == null)
 					return size;
 
-				// 3) get Dictionary
+				// 2) get Dictionary
 				var iter_item = Unsafe.As<IDictionary<X,Y>>(_object).GetEnumerator();
 
-				// 4) add size of items
+				// 3) add size of items
 				while (iter_item.MoveNext())
 				{
 					size += _serializer_key.ProcessGetSizeOf(iter_item.Current.Key);
@@ -3940,13 +3941,13 @@ namespace CGDK
 					return;
 				}
 
-				// 2) write count 
+				// 1) write count 
 				Unsafe.AsRef<Int32>((void*)_ptr) = _object.Count;
 
-				// 3) update ptr
+				// 2) update ptr
 				_ptr += sizeof(Int32);
 
-				// 4) write
+				// 3) write
 				var iter_item = _object.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -3976,13 +3977,13 @@ namespace CGDK
 				// 3) create list
 				var obj = new List<V>();
 
-				// 5) sub count
+				// 4) sub count
 				_count -= sizeof(V) * item_count;
 
-				// 6) set capacity
+				// 5) set capacity
 				obj.Capacity = item_count;
 
-				// 7) write items
+				// 6) write items
 				while (item_count > 0)
 				{
 					// - add item
@@ -4202,7 +4203,7 @@ namespace CGDK
 				// check)
 				Debug.Assert(obj_list != null);
 
-				// 2) 'items'
+				// 3) 'items'
 				var iter_item = obj_list.GetEnumerator();
 				while (iter_item.MoveNext())
 				{
@@ -4271,10 +4272,10 @@ namespace CGDK
 				// 3) create list
 				var obj = new List<V>();
 
-				// 5) sub count
+				// 4) sub count
 				_count -= sizeof(V) * item_count;
 
-				// 6) set capacity
+				// 5) set capacity
 				obj.Capacity = item_count;
 
 				// 7) read all items
@@ -4299,7 +4300,7 @@ namespace CGDK
 				if (_object == null)
 					return sizeof(Int32);
 
-				// 4) casting to IList
+				// 1) casting to IList
 				var obj_list = Unsafe.As<List<V>>(_object);
 
 				// return) 
@@ -4831,7 +4832,7 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 1) build by type
+				// 2) build by type
 				if (type.IsPrimitive)
 					result = BuildSerailizer_Primitive(type);
 				else if (type.IsEnum)
@@ -5074,7 +5075,7 @@ namespace CGDK
 			}
 			private static object? BuildSerializer_Dictionary_typed<T>()
 			{
-				// 2) get argument type
+				// 1) get argument type
 				var types = typeof(T).GetGenericArguments();
 				var type_key = types[0];
 				var type_value = types[1];
@@ -5772,16 +5773,16 @@ namespace CGDK
 				if (IsSerializableType(_type) == false)
 					throw new System.NullReferenceException("class is not CGDK.serializable");
 
-				// 2) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
+				// 1) 부모의 부모가 nullptr이면 object를 제외하고 최고 부모 클래스다.
 				if (_type.BaseType != null && _type.BaseType.BaseType != null)
 				{
 					BuildSerializer_Class(_type.BaseType, ref _list_member_serialization_info);
 				}
 
-				// 3) member변수들을 얻는다.
+				// 2) member변수들을 얻는다.
 				var temp_field = _type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-				// 4) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
+				// 3) 최상위 부모의 맴버부터 차례대로 buffer 에 append 한다
 				foreach (var iter in temp_field)
 				{
 					// check)
@@ -5850,15 +5851,15 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 존재하지 않으면 새로 만든다.
+					// 3) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -5886,19 +5887,19 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(Dictionary<K, V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is IBase<Dictionary<K, V>>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 먼저 시돈
@@ -5913,7 +5914,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = Unsafe.As<IBase<Dictionary<K, V>>?>(result);
 
 				// check)
@@ -5927,19 +5928,19 @@ namespace CGDK
 				// declare) 
 				object? result = null;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(List<V>);
 
 				lock (dictionary_serializer)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer.TryGetValue(type, out result);
 
-					// 4) 이미 serializer가 있더라도 후진 serializer라면 교체
+					// 3) 이미 serializer가 있더라도 후진 serializer라면 교체
 					if (is_exist == true && result is SerializerList_typed<V>)
 						is_exist = false;
 
-					// 5) 존재하지 않으면 새로 만든다.
+					// 4) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - build
@@ -5954,7 +5955,7 @@ namespace CGDK
 					}
 				}
 
-				// 6) casting
+				// 5) casting
 				var result_casted = Unsafe.As<IBase<List<V>>?>(result);
 
 				// check)
@@ -5973,7 +5974,7 @@ namespace CGDK
 					// 1) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(_type, out result);
 
-					// 3) 존재하지 않으면 새로 만든다.
+					// 2) 존재하지 않으면 새로 만든다.
 					if (is_exist == false)
 					{
 						// - 종류에 다라 생성
@@ -6017,15 +6018,15 @@ namespace CGDK
 				if (_serializer == null)
 					return;
 
-				// 2) get type
+				// 1) get type
 				var type = typeof(T);
 
 				lock (dictionary_serializer_object)
 				{
-					// 3) 이미 존재하는 가?
+					// 2) 이미 존재하는 가?
 					var is_exist = dictionary_serializer_object.TryGetValue(type, out object? result);
 
-					// 4) 존재하지 않으면 추가 존재하면 교체
+					// 3) 존재하지 않으면 추가 존재하면 교체
 					if (is_exist == false)
 						dictionary_serializer_object.Add(type, _serializer);
 					else

--- a/C#/unit_test/unit_test.functional/NET/CGDK.buffer.unit_test.functional.NET.csproj
+++ b/C#/unit_test/unit_test.functional/NET/CGDK.buffer.unit_test.functional.NET.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <Reference Include="CGDK.buffer.NET">
-      <HintPath>..\..\..\dll\CGDK.buffer.NET.dll</HintPath>
+    <Reference Include="CGDK.buffer">
+      <HintPath>..\..\..\dll\CGDK.buffer.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/C#/unit_test/unit_test.functional/unit_test_functional.cs
+++ b/C#/unit_test/unit_test.functional/unit_test_functional.cs
@@ -1642,6 +1642,115 @@ namespace CGDBuffer_CSharp_UnitTest
 			}
 		}
 
+
+		[TestMethod]
+		public void test_buffer_append_extract_List_int_null()
+		{
+			List<int>? list_null = null;
+
+			var size_source = CGDK.buffer.GetSizeOf(list_null);
+
+			for (int i = 0; i < _TEST_COUNT; ++i)
+			{
+				// - Buffer 할당
+				var buf_temp = new CGDK.buffer(2048);
+
+				// - 값 써넣기
+				buf_temp.Append(list_null);
+
+				// check) 
+				Assert.IsTrue(size_source == buf_temp.Count);
+
+				var temp = buf_temp.Extract<List<int>>();
+
+				// check) 
+				Assert.IsTrue(buf_temp.Count == 0);
+				Assert.IsTrue(temp == null);
+			}
+		}
+
+		[TestMethod]
+		public void test_buffer_append_extract_array_int_zero_size()
+		{
+			var array_empty = new int[0];
+
+			var size_source = CGDK.buffer.GetSizeOf(array_empty);
+
+			for (int i = 0; i < _TEST_COUNT; ++i)
+			{
+				// - Buffer 할당
+				var buf_temp = new CGDK.buffer(2048);
+
+				// - 값 써넣기
+				buf_temp.Append(array_empty);
+
+				// check) 
+				Assert.IsTrue(size_source == buf_temp.Count);
+
+				var temp = buf_temp.Extract<List<int>>();
+
+				// check) 
+				Assert.IsTrue(buf_temp.Count == 0);
+				Assert.IsTrue(temp != null);
+				Assert.IsTrue(temp.Count == 0);
+			}
+		}
+
+		[TestMethod]
+		public void test_buffer_append_extract_List_int_zero_size()
+		{
+			var list_empty = new List<int>();
+
+			var size_source = CGDK.buffer.GetSizeOf(list_empty);
+
+			for (int i = 0; i < _TEST_COUNT; ++i)
+			{
+				// - Buffer 할당
+				var buf_temp = new CGDK.buffer(2048);
+
+				// - 값 써넣기
+				buf_temp.Append(list_empty);
+
+				// check) 
+				Assert.IsTrue(size_source == buf_temp.Count);
+
+				var temp = buf_temp.Extract<List<int>>();
+
+				// check) 
+				Assert.IsTrue(buf_temp.Count == 0);
+				Assert.IsTrue(temp != null);
+				Assert.IsTrue(temp.Count == 0);
+			}
+		}
+
+
+		public void test_buffer_append_extract_array_string_zero_size()
+		{
+			var list_empty = new List<string>();
+
+			var size_source = CGDK.buffer.GetSizeOf(list_empty);
+
+			for (int i = 0; i < _TEST_COUNT; ++i)
+			{
+				// - Buffer 할당
+				var buf_temp = new CGDK.buffer(2048);
+
+				// - 값 써넣기
+				buf_temp.Append(list_empty);
+
+				// check) 
+				Assert.IsTrue(size_source == buf_temp.Count);
+
+				var temp = buf_temp.Extract<List<string>>();
+
+				// check) 
+				Assert.IsTrue(buf_temp.Count == 0);
+				Assert.IsTrue(temp != null);
+				Assert.IsTrue(temp.Count == 0);
+			}
+		}
+
+
 		[TestMethod]
 		public void test_buffer_append_array_int_extract_int()
 		{
@@ -3018,6 +3127,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_offset_bound_plus()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3045,7 +3157,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}
@@ -3053,6 +3165,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_offset_minus()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3086,8 +3201,9 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
+
 				}
 			}
 		}
@@ -3095,6 +3211,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_size_minus()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3126,7 +3245,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}
@@ -3134,6 +3253,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_size_plus()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(24);
@@ -3166,7 +3288,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}
@@ -3174,6 +3296,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_operator_set_offset()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3205,7 +3330,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}
@@ -3213,6 +3338,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_operator_set_size()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3244,7 +3372,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}
@@ -3252,6 +3380,9 @@ namespace CGDBuffer_CSharp_UnitTest
 		[TestMethod]
 		public void test_buffer_operator_set_offset_size()
 		{
+			// 경게 테스트
+			// Debug 모드 일 경우 Assert가 활성화되어 실패 남
+
 			var buf_Alloc = new CGDK.buffer();
 
 			buf_Alloc.Alloc(256);
@@ -3283,7 +3414,7 @@ namespace CGDBuffer_CSharp_UnitTest
 					// check) 
 					Assert.IsTrue(false);
 				}
-				catch (System.IndexOutOfRangeException)
+				catch (System.Exception)
 				{
 				}
 			}

--- a/C#/unit_test/unit_test.performance.CGDK/NET/CGDK.buffer.unit_test.performance.CGDK.NET.csproj
+++ b/C#/unit_test/unit_test.performance.CGDK/NET/CGDK.buffer.unit_test.performance.CGDK.NET.csproj
@@ -28,10 +28,11 @@
   <ItemGroup>
     <Analyzer Include="..\..\..\dll\CGDK.buffer.Generator.dll" />
   </ItemGroup>
+
   <ItemGroup>
-  <Reference Include="CGDK.buffer.NET">
-    <HintPath>..\..\..\dll\CGDK.buffer.NET.dll</HintPath>
-  </Reference>
+    <Reference Include="CGDK.buffer">
+      <HintPath>..\..\..\dll\CGDK.buffer.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <Import Project="..\CGDK.buffer.unit_test.performance.CGDK.projitems" Label="Shared" />

--- a/C++/ReadMe.md
+++ b/C++/ReadMe.md
@@ -1,44 +1,47 @@
 ## CGDK::buffer 설정하기.
 특별한 설정은 없습니다만
 - C++17이상의 버전 설정<br>
-- 'CGDK.buffer/C++/include'를 include 디렉토리에 포함시켜 주십시요.<br>
-- 소스 파일에 '#include "cgdk/shared_buffer"'를 추가해 사용하시면 됩니다.<br>
+- ``CGDK.buffer/C++/include``를 ``include`` 디렉토리에 포함시켜 주십시요.<br>
+- 소스 파일에 ``#include "cgdk/shared_buffer"``를 추가해 사용하시면 됩니다.<br>
 visual studio, linux, unreal 3D 모두 설정이 동일합니다.<br>
-자세한 설정 방법은 문서(' https://github.com/CGLabs/CGDK.buffer/blob/master/C%2B%2B/document/Getting_start_CGDK.buffer.pptx ')를 참조해 주십시요.<br>
+자세한 설정 방법은 [설명 문서](https://github.com/CGLabs/CGDK.buffer/blob/master/C%2B%2B/document/Getting_start_CGDK.buffer.pptx)를 참조해 주십시요.<br>
+<br>
 
 ### '/project'
-- 그냥 CGDK::buffer를 visual studio에서 볼 수 있도록 project를 만들어 놓은 것일 뿐 header 파일로만 되어 있어 컴파일을 하실 필요 없고 할 수도 없습니다.<br>
+- 그냥 ``CGDK::buffer``를 ``visual studio``에서 볼 수 있도록 project를 만들어 놓은 것일 뿐 header 파일로만 되어 있어 컴파일을 하실 필요 없고 할 수도 없습니다.<br>
+<br>
 
 ### '/tutorials'
 #### comment
    - 5개의 튜터리얼로 구성되어 있습니다.<br>
-      [tutorial 1] 기본 사용법: 다양한 자료형 직렬화/역직렬화를 위한 append/extract/front 함수 등의 사용법을  설명합니다.<br>
-      [tutorial 2] 버퍼 조작: 버퍼 자체를 조작하는 방법들을 설명합니다. (버퍼 깊은 복사, CGDK::buffer_view와 CGDK::buffer 용도, 버퍼 연사자 등...)<br>
+      [tutorial 1] 기본 사용법: 다양한 자료형 직렬화/역직렬화를 위한 ``append``/``extract``/``front`` 함수 등의 사용법을  설명합니다.<br>
+      [tutorial 2] 버퍼 조작: 버퍼 자체를 조작하는 방법들을 설명합니다. (버퍼 깊은 복사, ``CGDK::buffer_view``와 ``CGDK::buffer`` 용도, 버퍼 연사자 등...)<br>
       [tutorial 3] 구조체 직렬화: idl을 대신한 구조체 직렬화의 사용법과 예제를 보여줍니다.<br>
-      [tutorial 4] Ibuffer_serialzation: 사용자 정의 schemaless 직렬화를 설정합니다. 구조체 직렬화를 사용하기 힘들거나 직접 직렬화/역직렬화를 정의할 필요가 있은 때 사용합니다.<br>
+      [tutorial 4] ``Ibuffer_serialzation``: 사용자 정의 schemaless 직렬화를 설정합니다. 구조체 직렬화를 사용하기 힘들거나 직접 직렬화/역직렬화를 정의할 필요가 있은 때 사용합니다.<br>
       [tutorial 5] unreal 3D 예제: (필요 이상으로 커서 포함하시지 않았습니다.)<br>
-      [tutorial 6] 정적 버퍼: CGDK::buffer를 사용해 배열이나 std::array와 같은 정적 변수를 버퍼로 사용하는 벙법을 설명합니다.<br>
+      [tutorial 6] 정적 버퍼: ``CGDK::buffer``를 사용해 배열이나 ``std::array``와 같은 정적 변수를 버퍼로 사용하는 벙법을 설명합니다.<br>
 #### compile
-   - Visual studio는 프로젝트 파일('CGDK.buffer.github/C++/tutorial/CGDK.buffer.tutorial.vs17.sln)'을 열어서 컴파일 하시면 됩니다.<br>
-   - Linux는 'CMake를 사용해서 컴파일 하시면 됩니다.<br>
-   'CGDK.buffer.github/C++/tutorial' 디렉토리에서<br>
+   - Visual studio는 프로젝트 파일(``CGDK.buffer.github/C++/tutorial/CGDK.buffer.tutorial.vs17.sln``)을 열어서 컴파일 하시면 됩니다.<br>
+   - Linux는 ``CMake``를 사용해서 컴파일 하시면 됩니다.<br>
+   ``CGDK.buffer.github/C++/tutorial`` 디렉토리에서<br>
 ``` bash
       > CMake . -DCMAKE_BUILD_TYPE=Debug 
       > make
 ```
-   를 실행하시면 됩니다. Release로 컴파일을 원하실 경우 '-DCMAKE_BUILD_TYPE'옵션을 Release로만 바꾸어 주시면 됩니다.<br>
+   를 실행하시면 됩니다. ``Release``로 컴파일을 원하실 경우 ``-DCMAKE_BUILD_TYPE``옵션을 Release로만 바꾸어 주시면 됩니다.<br>
+<br>
 
 ### '/uint_test'
 #### comment
-   - unit test는 google test를 사용하여 작성되었습니다.<br>
+   - unit test는 ``google test``를 사용하여 작성되었습니다.<br>
    - 2가지의 unit test가 있습니다.<br>
-   'unit_test.benchmark.basic' : protobuf,flatbuffers와의 성능 비교를 위한 unit test입니다.<br>
-   'unit_test.function' : CGDK::buffer의 오류가 없는지를 검사하는 unit test입니다.<br>
+   ``unit_test.benchmark.basic`` : ``protobuf``,``flatbuffers``와의 성능 비교를 위한 unit test입니다.<br>
+   ``unit_test.function`` : ``CGDK::buffer``의 오류가 없는지를 검사하는 unit test입니다.<br>
 #### compile
    - Visual studio는 프로젝트 파일('CGDK.buffer.github/C++/unit_test/CGDK.buffer.unit_test.vs17.sln')을 열어서 컴파일 하시면 됩니다.<br>
-   - vcpkg를 사용하므로 필요한 모듈(gtest,protobuf,flatbuffers)는 'CGDK.buffer/C++/unit_test/vcpkg_installed'에 자동으로 설치됩니다.<br>
-   - Linux를 사용하실 경우 'CMake를 사용해서 컴파일 하시면 됩니다.<br>
-   - 하지만 사전에 gtest,protobuf,flatbuffers를 설치하시길 바랍니다.<br>
+   - ``vcpkg``를 사용하므로 필요한 모듈(``gtest``,``protobuf``,``flatbuffers``)는 ``CGDK.buffer/C++/unit_test/vcpkg_installed``에 자동으로 설치됩니다.<br>
+   - Linux를 사용하실 경우 ``CMake``를 사용해서 컴파일 하시면 됩니다.<br>
+   - 하지만 사전에 ``gtest``,``protobuf``,``flatbuffers``를 설치하시길 바랍니다.<br>
    [ubuntu 기준]<br>
    ``` bash
       > sudo apt install libgtest-dev
@@ -46,10 +49,10 @@ visual studio, linux, unreal 3D 모두 설정이 동일합니다.<br>
       > snap install flatbuffers
    ```
    로 설치하시면 됩니다.<br>
-   그 이후에 CGDK.buffer.github/C++/unit_test 디렉토리에서<br>
+   그 이후에 ``CGDK.buffer.github/C++/unit_test`` 디렉토리에서<br>
    ``` bash
       > CMake . -DCMAKE_BUILD_TYPE=Debug 
       > make
    ```
-   를 실행하시면 됩니다. Release로 컴파일을 원하실 경우 '-DCMAKE_BUILD_TYPE'옵션을 Release로만 바꾸어 주시면 됩니다.<br>
+   를 실행하시면 됩니다. Release로 컴파일을 원하실 경우 ``-DCMAKE_BUILD_TYPE``옵션을 Release로만 바꾸어 주시면 됩니다.<br>
 

--- a/C++/include/cgdk/buffers/_basic_buffer.h
+++ b/C++/include/cgdk/buffers/_basic_buffer.h
@@ -136,7 +136,7 @@ public:
 			template <class T>																					  
 	constexpr prpd_tr<T>		prepend(const T& _data) { return PRPD_t<self_t, T>::_do_prepend(*this, _data);;}
 			template <class T>																					  
-	constexpr prpd_tr<T>		prepend(T&& _data) { return PRPD_t<self_t, T>::_do_prepend(*this, _data); _data = T();}
+	constexpr prpd_tr<T>		prepend(T&& _data) { return PRPD_t<self_t, T>::_do_prepend(*this, std::move(_data));}
 			template <class T> 																					  
 	constexpr base_t			prepend(const T* _data, std::size_t _count) { return _prepend_array(_data, _count);}
 			template <class T> 																					  

--- a/C++/include/cgdk/buffers/_basic_buffer.h
+++ b/C++/include/cgdk/buffers/_basic_buffer.h
@@ -21,6 +21,7 @@
 namespace CGDK
 {
 #if defined(FMT_FORMAT_H_)
+	#define _CGDBUFFER_FMT
 	template <class T, class... TREST>
 	constexpr std::basic_string<T> _fmt_format_string(std::basic_string_view<T> _format, TREST&&... _rest)
 	{
@@ -34,6 +35,7 @@ namespace CGDK
 			static_assert(false, "no {fmt} support");
 		}
 	#else
+		#define _CGDBUFFER_FMT
 		template <class... TREST>
 		constexpr std::string _fmt_format_string(std::string_view _format, TREST&&... _rest)
 		{
@@ -474,7 +476,7 @@ public:
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								_prepend_string_format(const T* _format, TREST&&... _rest)
 	{
-#if defined(FMT_FORMAT_H_) || defined(__cpp_lib_format)
+#if defined(_CGDBUFFER_FMT)
 		// check) _format must not be nullptr
 		CGDK_ASSERT(_format != nullptr, throw std::invalid_argument("_format is nullptr [0]"));
 
@@ -510,10 +512,9 @@ public:
 		return base_t(this->data_, buf_old - p);
 #else
 		#if defined(__cpp_lib_format)
-			//static_assert(false, "include <format> before including 'CGDK.buffer'");
+			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
 			throw std::exception("include <format> before including 'CGDK.buffer'");
 		#else
-			//static_assert(false, "'std::format' is not supported");
 			throw std::exception("'std::format' is not supported");
 		#endif
 #endif
@@ -581,7 +582,7 @@ public:
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								_prepend_text_format(const T* _format, TREST&&... _rest)
 	{
-#if defined(FMT_FORMAT_H_) || defined(__cpp_lib_format)
+#if defined(_CGDBUFFER_FMT)
 		// check) _string이 nullptr이면 안된다.
 		CGDK_ASSERT(_format != nullptr, throw std::invalid_argument("_format is nullptr! [0]"));
 
@@ -606,10 +607,9 @@ public:
 		return base_t(p, size_string);
 #else
 		#if defined(__cpp_lib_format)
-			//static_assert(false, "include <format> before including 'CGDK.buffer'");
+			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
 			throw std::exception("include <format> before including 'CGDK.buffer'");
 		#else
-			//static_assert(false, "'std::format' is not supported");
 			throw std::exception("'std::format' is not supported");
 		#endif
 #endif
@@ -1178,7 +1178,7 @@ public:
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								_append_string_format(std::basic_string_view<T> _format, TREST&&... _rest)
 	{
-#if defined(FMT_FORMAT_H_) || defined(__cpp_lib_format)
+#if defined(_CGDBUFFER_FMT)
 		// 1) get formatted string
 		auto temp_buffer = _fmt_format_string(_format, std::forward<TREST>(_rest)...);
 		const auto length_string = temp_buffer.size() + 1;
@@ -1206,10 +1206,9 @@ public:
 		return base_t(buf_dest, added_length);
 #else
 		#if defined(__cpp_lib_format)
-			//static_assert(false, "include <format> before including 'CGDK.buffer'");
+			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
 			throw std::exception("include <format> before including 'CGDK.buffer'");
 		#else
-			//static_assert(false, "'std::format' is not supported");
 			throw std::exception("'std::format' is not supported");
 		#endif
 #endif
@@ -1319,7 +1318,7 @@ public:
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								_append_text_sprintf(const T* _format, TREST&&... _rest)
 	{
-#if defined(FMT_FORMAT_H_) || defined(__cpp_lib_format)
+#if defined(_CGDBUFFER_FMT)
 		//// 1) get max length
 		//const std::size_t max_length = _buffer_string_size_saturate((reinterpret_cast<const T*>(bound_upper) - reinterpret_cast<const T*>(buf_dest + sizeof(COUNT_T))));
 
@@ -1347,10 +1346,9 @@ public:
 		return base_t(buf_dest, added_length);
 #else
 		#if defined(__cpp_lib_format)
-			//static_assert(false, "include <format> before including 'CGDK.buffer'");
+			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
 			throw std::exception("include <format> before including 'CGDK.buffer'");
 		#else
-			//static_assert(false, "'std::format' is not supported");
 			throw std::exception("'std::format' is not supported");
 		#endif
 #endif
@@ -1409,9 +1407,10 @@ public:
 		_append_text_format(const T* _format, TFIRST && _first, TREST&&... _rest)
 	{
 		#if defined(__cpp_lib_format)
-			static_assert(false, "include <format> before including 'CGDK.buffer'");
+			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
+			throw std::exception("include <format> before including 'CGDK.buffer'");
 		#else
-			static_assert(false, "'std::format' is not supported");
+			throw std::exception("'std::format' is not supported");
 		#endif
 	}
 #endif

--- a/C++/include/cgdk/buffers/_basic_buffer.h
+++ b/C++/include/cgdk/buffers/_basic_buffer.h
@@ -145,16 +145,16 @@ public:
 								append(I _first, I _last) { return _append_iterator(_first, _last);}
 	constexpr auto				append(std::size_t _size, const void* _buffer) { return this->_append_bytes(_size, _buffer); }
 
-			template <class T>
+			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(const std::basic_string_view<T> _text) { return this->_append_text(_text);}
-			template <class T>
+								append_text(const std::basic_string_view<T> _text) { return this->_append_text<T>(_text);}
+			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(const std::basic_string<T>& _text) { return this->_append_text(std::basic_string_view<T>(_text));}
+								append_text(const std::basic_string<T>& _text) { return this->_append_text<T>(std::basic_string_view<T>(_text));}
 
-			template <class T, std::size_t N>
+			template <class T = char, std::size_t N>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(const T(&_text)[N]) { return this->_append_text(_text);}
+								append_text(const T(&_text)[N]) { return this->_append_text<T>(_text);}
 			template <class T = char, class TNUM>
 	constexpr std::enable_if_t<std::is_integral_v<TNUM>, base_t>
 				 				append_text(TNUM _value) { return this->_append_text_integer<T>(_value);}

--- a/C++/include/cgdk/buffers/_basic_buffer.h
+++ b/C++/include/cgdk/buffers/_basic_buffer.h
@@ -14,40 +14,8 @@
 
 #pragma once
 
-#if !defined(FMT_FORMAT_H_) && defined(__cpp_lib_format)
-	#include <format>
-#endif
-
 namespace CGDK
 {
-#if defined(FMT_FORMAT_H_)
-	#define _CGDBUFFER_FMT
-	template <class T, class... TREST>
-	constexpr std::basic_string<T> _fmt_format_string(std::basic_string_view<T> _format, TREST&&... _rest)
-	{
-		return fmt::format(_format, std::forward<TREST>(_rest)...);
-	}
-#else
-	#if !defined(__cpp_lib_format)
-		template <class T, class... TREST>
-		constexpr std::basic_string<T> _fmt_format_string(std::basic_string_view<T> _format, TREST&&... _rest)
-		{
-			static_assert(false, "no {fmt} support");
-		}
-	#else
-		#define _CGDBUFFER_FMT
-		template <class... TREST>
-		constexpr std::string _fmt_format_string(std::string_view _format, TREST&&... _rest)
-		{
-			return std::vformat(_format, std::make_format_args(std::forward<TREST>(_rest)...));
-		}
-		template <class... TREST>
-		constexpr std::wstring _fmt_format_string(std::wstring_view _format, TREST&&... _rest)
-		{
-			return std::vformat(_format, std::make_wformat_args(std::forward<TREST>(_rest)...));
-		}
-	#endif
-#endif
 
 template <class ELEM_T>
 class _basic_buffer : public _buffer_view<char>
@@ -149,25 +117,10 @@ public:
 			auto				prepend(std::size_t _size, const void* _buffer) { return _prepend_bytes(_size, _buffer);}
 			template <class T>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								prepend_string(std::basic_string_view<T> _text) { return _prepend_string(_text);}
-			template <class T, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								prepend_string(const std::basic_string_view<T> _format, F&& _first, TREST&&... _rest) { return _prepend_string_format(_format.data(), std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-			template <class T, std::size_t N, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								prepend_string(const T(&_format)[N], F&& _first, TREST&&... _rest) { return _prepend_string_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-			template <class T>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								prepend_text(std::string_view _text) { return _prepend_text(_text);}
 			template <class T, std::size_t N>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								prepend_text(const T(&_text)[N]) { return _prepend_text(_text);}
-			template <class T, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								prepend_text(std::basic_string_view<T> _format, F&& _first, TREST&&... _rest) { return _prepend_text_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-			template <class T, std::size_t N, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								prepend_text(const T(&_format)[N], F&& _first, TREST&&... _rest) { return _prepend_text_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
 
 	// 4) append
 			template <std::size_t N>
@@ -192,26 +145,16 @@ public:
 								append(I _first, I _last) { return _append_iterator(_first, _last);}
 	constexpr auto				append(std::size_t _size, const void* _buffer) { return this->_append_bytes(_size, _buffer); }
 
-			template <class T, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append(std::basic_string_view<T> _format, F&& _first, TREST&&... _rest) { return this->_append_string_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-			template <class T, std::size_t N, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append(const T(&_format)[N], F&& _first, TREST&&... _rest) { return this->_append_string_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
 			template <class T>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(std::basic_string_view<T> _text) { return this->_append_text(_text);}
+								append_text(const std::basic_string_view<T> _text) { return this->_append_text(_text);}
+			template <class T>
+	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
+								append_text(const std::basic_string<T>& _text) { return this->_append_text(std::basic_string_view<T>(_text));}
 
 			template <class T, std::size_t N>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								append_text(const T(&_text)[N]) { return this->_append_text(_text);}
-			template <class T, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(std::basic_string_view<T> _format, F&& _first, TREST&&... _rest) { return this->_append_text_format(_format.data(), std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-			template <class T, std::size_t N, class F, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								append_text(const T(&_format)[N] , F&& _first, TREST&&... _rest) { return this->_append_text_format(_format, std::forward<F>(_first), std::forward<TREST>(_rest)...);}
-
 			template <class T = char, class TNUM>
 	constexpr std::enable_if_t<std::is_integral_v<TNUM>, base_t>
 				 				append_text(TNUM _value) { return this->_append_text_integer<T>(_value);}
@@ -472,53 +415,6 @@ public:
 		return base_t(p, added_length);
 	}
 
-	template <class T, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								_prepend_string_format(const T* _format, TREST&&... _rest)
-	{
-#if defined(_CGDBUFFER_FMT)
-		// check) _format must not be nullptr
-		CGDK_ASSERT(_format != nullptr, throw std::invalid_argument("_format is nullptr [0]"));
-
-		// 1) store data_
-		auto buf_old = this->data_;
-
-		// 2) [원본_버퍼_시작_크기]에 [형식_문자열]를 써넣는다.
-		auto temp_buffer = _fmt_format_string(std::basic_string_view<T>(_format), std::forward<TREST>(_rest)...);
-		const auto str_start = temp_buffer.data();
-		const auto length_string = temp_buffer.size() + 1;
-		const auto size_string = length_string * sizeof(T);
-
-		// 3) [목표_포인터]를 구한다.
-		auto p = this->data_ - size_string;
-
-		// check) lower bound
-		_CGD_BUFFER_BOUND_CHECK((p - sizeof(COUNT_T)) >= this->get_lower_bound());
-	
-		// 4) [문자열]을 복사한다.
-		memcpy(p, str_start, size_string);
-
-		// 5) [목표_포인터]를 sizeof(COUNT_T)만큼을 뺀다.
-		p -= sizeof(COUNT_T);
-
-		// 6) [문자열_길이]를 써넣는다.
-		*reinterpret_cast<COUNT_T*>(p) = static_cast<COUNT_T>(length_string);
-
-		// 7)[원본_버퍼_포인터]를 업데이트한다.
-		this->data_ = p;
-		this->size_ += size_string + sizeof(COUNT_T);
-
-		// return) 
-		return base_t(this->data_, buf_old - p);
-#else
-		#if defined(__cpp_lib_format)
-			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
-			throw std::exception("include <format> before including 'CGDK.buffer'");
-		#else
-			throw std::exception("'std::format' is not supported");
-		#endif
-#endif
-	}
 	template <class T>
 	constexpr base_t			_prepend_text(std::string_view _string)
 	{
@@ -576,43 +472,6 @@ public:
 
 		// return) 
 		return base_t(p, size_string);
-	}
-
-	template <class T, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								_prepend_text_format(const T* _format, TREST&&... _rest)
-	{
-#if defined(_CGDBUFFER_FMT)
-		// check) _string이 nullptr이면 안된다.
-		CGDK_ASSERT(_format != nullptr, throw std::invalid_argument("_format is nullptr! [0]"));
-
-		auto temp_buffer = _fmt_format_string(std::basic_string_view<T>(_format), std::forward<TREST>(_rest)...);
-		const auto str_start = temp_buffer.data();
-		const auto size_string = (temp_buffer.size() + 1) * sizeof(T);
-
-		// 6) [원본_버퍼_포인터]를 [문자열 길이] 만큼 뺀 [목표_포인터]를 구한다..
-		auto p = this->data_ - size_string;
-
-		// check) lower bound
-		_CGD_BUFFER_BOUND_CHECK(p >= this->get_lower_bound());
-
-		// 7) [문자열]을 추가한다.
-		memcpy(p, str_start, size_string);
-
-		// 9) [원본_버퍼_포인터]와 [원본_버퍼_길이]를 옮긴다.
-		this->data_ = p;
-		this->size_ += size_string;
-
-		// return) 
-		return base_t(p, size_string);
-#else
-		#if defined(__cpp_lib_format)
-			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
-			throw std::exception("include <format> before including 'CGDK.buffer'");
-		#else
-			throw std::exception("'std::format' is not supported");
-		#endif
-#endif
 	}
 	constexpr base_t			_prepend_bytes(std::size_t _size, const void* _buffer)
 	{
@@ -1174,51 +1033,6 @@ public:
 		// return) 리턴
 		return base_t(buf_dest, added_length);
 	}
-	template <class T, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								_append_string_format(std::basic_string_view<T> _format, TREST&&... _rest)
-	{
-#if defined(_CGDBUFFER_FMT)
-		// 1) get formatted string
-		auto temp_buffer = _fmt_format_string(_format, std::forward<TREST>(_rest)...);
-		const auto length_string = temp_buffer.size() + 1;
-		const auto size_string = length_string * sizeof(T);
-
-		// 2) get [dest]
-		const auto buf_dest = this->data_ + this->size_;
-
-		// check) upper bound
-		_CGD_BUFFER_BOUND_CHECK((buf_dest + sizeof(COUNT_T) + size_string) <= this->get_upper_bound());
-
-		// 4) store [string_length]
-		*reinterpret_cast<COUNT_T*>(buf_dest) = static_cast<COUNT_T>(length_string);
-
-		// 5) copy string to buffer
-		::memcpy(buf_dest + sizeof(COUNT_T), temp_buffer.data(), size_string);
-
-		// 6) get added length
-		const auto added_length = size_string + sizeof(COUNT_T);
-
-		// 7) update [size_]
-		this->size_ += added_length;
-
-		// return)
-		return base_t(buf_dest, added_length);
-#else
-		#if defined(__cpp_lib_format)
-			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
-			throw std::exception("include <format> before including 'CGDK.buffer'");
-		#else
-			throw std::exception("'std::format' is not supported");
-		#endif
-#endif
-	}
-	template <class T, std::size_t N, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								_append_string_format(const T(&_format)[N], TREST&&... _rest)
-	{
-		return _append_string_format(std::basic_string_view<T>(_format), std::forward<TREST>(_rest)...);
-	}
 	template <class T>
 	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
 								_append_text(std::basic_string_view<T> _string)
@@ -1314,106 +1128,6 @@ public:
 		// return) 
 		return base_t(buf_dest, size_string);
 	}
-	template <class T, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-								_append_text_sprintf(const T* _format, TREST&&... _rest)
-	{
-#if defined(_CGDBUFFER_FMT)
-		//// 1) get max length
-		//const std::size_t max_length = _buffer_string_size_saturate((reinterpret_cast<const T*>(bound_upper) - reinterpret_cast<const T*>(buf_dest + sizeof(COUNT_T))));
-
-		// 1) get formatted string
-		auto temp_buffer = _fmt_format_string(std::basic_string_view<T>(_format), std::forward<TREST>(_rest)...);
-		const auto length_string = temp_buffer.size();
-		const auto size_string = length_string * sizeof(T);
-
-		// 2) get [dest]
-		const auto buf_dest = this->data_ + this->size_;
-
-		// check) upper bound
-		_CGD_BUFFER_BOUND_CHECK((buf_dest + size_string) <= this->get_upper_bound());
-
-		// 5) copy string to buffer
-		::memcpy(buf_dest, temp_buffer.data(), size_string);
-
-		// 6) get added length
-		const auto added_length = size_string;
-
-		// 7) update [size_]
-		this->size_ += added_length;
-
-		// return)
-		return base_t(buf_dest, added_length);
-#else
-		#if defined(__cpp_lib_format)
-			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
-			throw std::exception("include <format> before including 'CGDK.buffer'");
-		#else
-			throw std::exception("'std::format' is not supported");
-		#endif
-#endif
-	}
-
-#if defined(FMT_FORMAT_H_)
-	template <class T, class TFIRST, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-		_append_text_format(const T* _format, TFIRST&& _first, TREST&&... _rest)
-	{
-		// declare) 
-		fmt::basic_memory_buffer<T> temp_buffer;
-
-		// 1) Generate trace Message
-		fmt::format_to(temp_buffer, _format, std::forward<TFIRST>(_first), std::forward<TREST>(_rest)...);
-
-		// check)
-		if (temp_buffer.size() <= 0)
-			return base_t();
-
-		// return) 
-		return this->_append_text(std::basic_string_view<T>(temp_buffer.data(), temp_buffer.size()));
-	}
-
-#elif defined(__cpp_lib_format)
-	template <class TFIRST, class... TREST>
-	base_t _append_text_format(const char* _format, TFIRST&& _first, TREST&&... _rest)
-	{
-		// 1) Generate trace Message
-		auto temp_buffer = std::vformat(_format, std::make_format_args(std::forward<TFIRST>(_first), std::forward<TREST>(_rest)...));;
-
-		// check)
-		if (temp_buffer.size() <= 0)
-			return base_t();
-
-		// return) 
-		return this->_append_text(std::string_view(temp_buffer.data(), temp_buffer.size()));
-	}
-	template <class TFIRST, class... TREST>
-	base_t _append_text_format(const wchar_t* _format, TFIRST&& _first, TREST&&... _rest)
-	{
-		// 1) Generate trace Message
-		auto temp_buffer = std::vformat(_format, std::make_wformat_args(std::forward<TFIRST>(_first), std::forward<TREST>(_rest)...));;
-
-		// check)
-		if (temp_buffer.size() <= 0)
-			return base_t();
-
-		// return) 
-		return this->_append_text(std::wstring_view(temp_buffer.data(), temp_buffer.size()));
-	}
-
-#else
-	template <class T, class TFIRST, class... TREST>
-	constexpr std::enable_if_t<is_string_type<T>::value, base_t>
-		_append_text_format(const T* _format, TFIRST && _first, TREST&&... _rest)
-	{
-		#if defined(__cpp_lib_format)
-			CGDK_ASSERT(false, "include <format> before including 'CGDK.buffer'");
-			throw std::exception("include <format> before including 'CGDK.buffer'");
-		#else
-			throw std::exception("'std::format' is not supported");
-		#endif
-	}
-#endif
 	constexpr base_t			_append_bytes(std::size_t _size, const void* _buffer)
 	{
 		// check) _buffer이 nullptr이면 안된다.
@@ -1532,7 +1246,7 @@ public:
 	constexpr base_t			_append_text_integer(uint64_t _value)
 	{
 		// declare) 
-		T temp_buf[32];
+		T temp_buf[32]{};
 		auto pos_now = temp_buf;
 
 		// 1) ...
@@ -1574,7 +1288,7 @@ public:
 	constexpr base_t			_append_text_integer(int64_t _value)
 	{
 		// declare) 
-		T temp_buf[32];
+		T temp_buf[32]{};
 		auto pos_now = temp_buf;
 
 		// 1-1) positive value

--- a/C++/include/cgdk/buffers/_buffer_common.h
+++ b/C++/include/cgdk/buffers/_buffer_common.h
@@ -21,13 +21,11 @@
 #include <stdexcept>
 #include <type_traits>
 
-// 2) stl
+// 2) memory
+#include <memory>
 #if !defined(_MSC_VER)
-	#include <memory.h>
 	#include <list>
 #endif
-#include <memory>
-#include <string>
 
 
 //-----------------------------------------------------------------------------

--- a/C++/include/cgdk/buffers/_buffer_view.h
+++ b/C++/include/cgdk/buffers/_buffer_view.h
@@ -36,24 +36,24 @@ public:
 	constexpr _buffer_view() noexcept {}
 	constexpr _buffer_view(_element_void_t<element_t>* _ptr, size_type _size = 0) noexcept : base_t{ _size, reinterpret_cast<element_t*>(_ptr) } {}
 	constexpr _buffer_view(const self_t& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } {}
-	constexpr _buffer_view(self_t&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } {}
+	constexpr _buffer_view(self_t&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } { _buffer = self_t(); }
 	template <class T>
 	constexpr _buffer_view(const _buffer_view<T>& _buffer) noexcept : base_t{ _buffer.size(), const_cast<std::remove_const_t<T>*>(_buffer.data()) } {}
 	template <class T>
-	constexpr _buffer_view(_buffer_view<T>&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } {}
+	constexpr _buffer_view(_buffer_view<T>&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } { _buffer=_buffer_view<T>(); }
 	constexpr _buffer_view(const base_t& _buffer) noexcept : base_t{ _buffer.size_, _buffer.data_ } {}
 	template <class T>
 	constexpr _buffer_view(const buffer_base<T>& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } {}
-	constexpr _buffer_view(base_t&& _buffer) noexcept : base_t{ _buffer.size_, _buffer.data_ } {}
+	constexpr _buffer_view(base_t&& _buffer) noexcept : base_t{ _buffer.size_, _buffer.data_ } { _buffer = base_t(); }
 	template <class T>
-	constexpr _buffer_view(buffer_base<T>&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } {}
+	constexpr _buffer_view(buffer_base<T>&& _buffer) noexcept : base_t{ _buffer.size(), _buffer.data() } { _buffer = buffer_base<T>(); }
 
 	template <class T, size_t N>
 	constexpr _buffer_view(T(&_array)[N]) noexcept : base_t{ N * sizeof(T), reinterpret_cast<element_t*>(_array) } {}
 	template <class T, size_t N>
 	constexpr _buffer_view(std::array<T, N>& _array) noexcept : base_t{ N * sizeof(T), reinterpret_cast<element_t*>(_array.data()) } {}
 	template <class T>
-	constexpr _buffer_view(std::basic_string_view<T> _string) noexcept : base_t{ _string.size() * sizeof(T), reinterpret_cast<element_t*>(const_cast<T*>(_string.data())) } {}
+	constexpr _buffer_view(std::basic_string_view<T> _string) noexcept : base_t{ _string.size() * sizeof(T), reinterpret_cast<element_t*>(_string.data()) } {}
 
 // public) 
 public:
@@ -126,66 +126,66 @@ public:
 			template<class... T>
 	constexpr self_t			extract(const std::tuple<T...>& _tuple)	{ auto buf_old = this->data_; _extract_tuple(_tuple); return self_t(buf_old, this->data_ - buf_old);}
 			template<class... T>
-	constexpr self_t			extract(std::tuple<T...>&& _tuple)		{ auto buf_old = this->data_; _extract_tuple(std::move(_tuple)); return self_t(buf_old, this->data_ - buf_old);}
-	constexpr std::string_view	extract_web_modify()					{ return _extract_web_modify();}
+	constexpr self_t			extract(std::tuple<T...>&& _tuple)		{ auto buf_old = this->data_; _extract_tuple(std::move(_tuple)); return self_t(buf_old, this->data_ - buf_old); _tuple = std::tuple<T...>(); }
+	constexpr std::string_view	extract_web_modify()					{ return this->_extract_web_modify();}
 			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, std::basic_string_view<T>>
-								extract_text(T _terminal = 0)			{ return _extract_text(_terminal);}
+								extract_text(T _terminal = 0)			{ return this->_extract_text(_terminal);}
 			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, std::basic_string_view<T>>
-								extract_text(T _terminal, T _modify)	{ return _extract_text(_terminal, _modify);}
+								extract_text(T _terminal, T _modify)	{ return this->_extract_text(_terminal, _modify);}
 			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, std::basic_string_view<T>>
 								extract_text(CGDK::size _length)		{ return _extract_text<T>(_length.amount);}
 
 			template <class T>
-	constexpr auto&				subtract()								{ return _subtract_general<T>();}
-	constexpr auto				subtract(size_type _length)				{ return _subtract_bytes(_length);}
+	constexpr auto&				subtract()								{ return this->_subtract_general<T>();}
+	constexpr auto				subtract(size_type _length)				{ return this->_subtract_bytes(_length);}
 
 	// 5) front
-	constexpr auto				front(int64_t _offset = 0) const		{ return _front(_offset);}
+	constexpr auto				front(int64_t _offset = 0) const		{ return this->_front(_offset);}
 			template <class T>
 	constexpr std::enable_if_t<!std::is_reference_v<T>, peek_tr<T>>
-								front(int64_t _offset = 0) const		{ return _front<T>(_offset);}
+								front(int64_t _offset = 0) const		{ return this->_front<T>(_offset);}
 			template <class T>
 	constexpr std::enable_if_t<std::is_reference_v<T>, T>
-								front(int64_t _offset = 0) const		{ return _front_general<std::remove_reference_t<std::remove_const_t<T>>>(_offset);}
+								front(int64_t _offset = 0) const		{ return this->_front_general<std::remove_reference_t<std::remove_const_t<T>>>(_offset);}
 			template <class T>
 	constexpr std::enable_if_t<!std::is_reference_v<T>, void>
-								front_to(T& _dest, int64_t _offset = 0) const { _front<T>(_dest, _offset);}
+								front_to(T& _dest, int64_t _offset = 0) const { this->_front<T>(_dest, _offset);}
 			template <class T>
 	constexpr std::enable_if_t<std::is_reference_v<T>, void>
-								front_to(T& _dest, int64_t _offset = 0) const { _front_general<std::remove_reference_t<std::remove_const_t<T>>>(_dest, _offset);}
+								front_to(T& _dest, int64_t _offset = 0) const { this->_front_general<std::remove_reference_t<std::remove_const_t<T>>>(_dest, _offset);}
 			template <class T>
 	constexpr std::enable_if_t<!std::is_reference_v<T>, peek_tr<T>>
-								front(offset& _pos) const				{ return _front<T>(_pos.amount);}
+								front(offset& _pos) const				{ return this->_front<T>(_pos.amount);}
 			template <class T>
 	constexpr std::enable_if_t<std::is_reference_v<T>, T>
-								front(offset& _pos) const				{ return _front_general<std::remove_reference_t<std::remove_const_t<T>>>(_pos.amount);}
+								front(offset& _pos) const				{ return this->_front_general<std::remove_reference_t<std::remove_const_t<T>>>(_pos.amount);}
 			template <class T>
 	constexpr std::enable_if_t<!std::is_reference_v<T>, void>
-								front_to(T& _dest, offset& _pos) const	{ _front<T>(_dest, _pos.amount);}
+								front_to(T& _dest, offset& _pos) const	{ this->_front<T>(_dest, _pos.amount);}
 			template <class T>
 	constexpr std::enable_if_t<std::is_reference_v<T>, void>
-								front_to(T& _dest, offset& _pos) const	{ _front_general<std::remove_reference_t<std::remove_const_t<T>>>(_dest, _pos.amount);}
+								front_to(T& _dest, offset& _pos) const	{ this->_front_general<std::remove_reference_t<std::remove_const_t<T>>>(_dest, _pos.amount);}
 			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, std::basic_string_view<T>>
-								front_text(T _terminal = 0, int64_t _offset = 0) { return _front(_text<T>(_terminal, _offset));}
+								front_text(T _terminal = 0, int64_t _offset = 0) { return this->_front(_text<T>(_terminal, _offset));}
 			template <class T = char>
 	constexpr std::enable_if_t<is_string_type<T>::value, std::basic_string_view<T>>
-								front_text(CGDK::size _length, int64_t _offset = 0) { return _front_text_by_length<T>(_length.amount, _offset);}
+								front_text(CGDK::size _length, int64_t _offset = 0) { return this->_front_text_by_length<T>(_length.amount, _offset);}
 
 	// 6) back
-	constexpr auto				back(int64_t _offset = 0) const			{ return _back(_offset);}
+	constexpr auto				back(int64_t _offset = 0) const			{ return this->_back(_offset);}
 			template <class T>
-	constexpr peek_tr<T>		back(int64_t _offset = 0) const			{ return _back<T>(_offset);}
+	constexpr peek_tr<T>		back(int64_t _offset = 0) const			{ return this->_back<T>(_offset);}
 			template <class T>
-	constexpr peek_tr<T>		back(offset& _pos) const				{ return _back<T>(_pos.amount);}
+	constexpr peek_tr<T>		back(offset& _pos) const				{ return this->_back<T>(_pos.amount);}
 
 	// 7) begin/end														  
-	constexpr auto				begin() const							{ return _begin();}
-	constexpr auto				end() const								{ return _end();}
-	constexpr auto				end(int _offset) const					{ return _end(_offset);}
+	constexpr auto				begin() const							{ return this->_begin();}
+	constexpr auto				end() const								{ return this->_end();}
+	constexpr auto				end(int _offset) const					{ return this->_end(_offset);}
 	constexpr auto				get_front_ptr() const noexcept			{ return this->data_;}
 			template <class T>
 	constexpr auto				get_front_ptr() const noexcept			{ return reinterpret_cast<T*>(this->data_); }
@@ -217,16 +217,16 @@ public:
 	constexpr self_t&			operator= (const self_t& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); return *this;}
 			template<class T>
 	constexpr self_t&			operator= (const _buffer_view<T>& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); return *this;}
-	constexpr self_t&			operator= (self_t&& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); return *this;}
+	constexpr self_t&			operator= (self_t&& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); _rhs.clear(); return *this; }
 			template<class T>
-	constexpr self_t&			operator= (_buffer_view<T>&& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); return *this;}
+	constexpr self_t&			operator= (_buffer_view<T>&& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); _rhs.clear(); return *this; }
 			// [operator] =				   
 	constexpr self_t&			operator= (const base_t& _rhs) noexcept { this->data_ =_rhs.data(); this->size_ =_rhs.size(); return *this;}
 			template<class T>
 	constexpr self_t&			operator= (const buffer_base<T>& _rhs) noexcept { this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
-	constexpr self_t&			operator= (base_t&& _rhs) noexcept { this->data_ =_rhs.data_; this->size_ =_rhs.size_; return *this;}
+	constexpr self_t&			operator= (base_t&& _rhs) noexcept { this->data_ =_rhs.data_; this->size_ =_rhs.size_; _rhs = base_t(); return *this;}
 			template<class T>
-	constexpr self_t&			operator= (buffer_base<T>&& _rhs) noexcept { this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
+	constexpr self_t&			operator= (buffer_base<T>&& _rhs) noexcept { this->data_ = _rhs.data(); this->size_ = _rhs.size(); _rhs = buffer_base<T>();return *this; }
 
 			// [operator] +=/-=
 	constexpr self_t&			operator+= (CGDK::offset _rhs)
@@ -252,11 +252,11 @@ public:
 			template<class T>
 	constexpr self_t&			operator^=(const _buffer_view<T>& _rhs)	{ this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
 			template<class T>
-	constexpr self_t&			operator^=(_buffer_view<T>&& _rhs) { this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
+			constexpr self_t& operator^=(_buffer_view<T>&& _rhs) { this->data_ = _rhs.data(); this->size_ = _rhs.size(); _rhs = _buffer_view<T>(); return *this; }
 			template<class T>
 	constexpr self_t&			operator^=(const buffer_base<T>& _rhs) { this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
 			template<class T>
-	constexpr self_t&			operator^=(buffer_base<T>&& _rhs) { this->data_ = _rhs.data(); this->size_ = _rhs.size(); return *this; }
+	constexpr self_t&			operator^=(buffer_base<T>&& _rhs) { this->data_ = _rhs.data(); this->size_ = _rhs.size(); _rhs = buffer_base<T>();return *this; }
 	constexpr self_t&			operator^=(size_type _rhs) { this->size_ = _rhs; return *this;}
 			// [operator] >> - extract
 			template <class T>

--- a/C++/include/cgdk/buffers/_buffer_view.h
+++ b/C++/include/cgdk/buffers/_buffer_view.h
@@ -53,7 +53,7 @@ public:
 	template <class T, size_t N>
 	constexpr _buffer_view(std::array<T, N>& _array) noexcept : base_t{ N * sizeof(T), reinterpret_cast<element_t*>(_array.data()) } {}
 	template <class T>
-	constexpr _buffer_view(std::basic_string_view<T> _string) noexcept : base_t{ _string.size() * sizeof(T), reinterpret_cast<element_t*>(_string.data()) } {}
+	constexpr _buffer_view(std::basic_string_view<T> _string) noexcept : base_t{ _string.size() * sizeof(T), reinterpret_cast<element_t*>(const_cast<T*>(_string.data())) } {}
 
 // public) 
 public:
@@ -61,8 +61,14 @@ public:
 	constexpr bool				exist() const noexcept					{ return this->size_ != 0;}
 	constexpr bool				empty() const noexcept					{ return this->size_ == 0;}
 	constexpr size_type			size() const noexcept					{ return this->size_;}
+#ifdef _WIN32
+	#pragma warning(disable:4267)
+#endif
 	template <class CAST_SIZE_T>
 	constexpr CAST_SIZE_T		size() const noexcept					{ CGDK_ASSERT(this->size_ == static_cast<size_type>(static_cast<CAST_SIZE_T>(this->size_))); return static_cast<CAST_SIZE_T>(this->size_);}
+#ifdef _WIN32
+	#pragma warning(default:4267)
+#endif
 	constexpr size_type			size_bytes() const noexcept				{ return this->size_ * sizeof(element_t);}
 	template <class CAST_SIZE_T>
 	constexpr CAST_SIZE_T		size_bytes() const noexcept				{ auto bytes = size_bytes(); CGDK_ASSERT(bytes == static_cast<size_type>(static_cast<CAST_SIZE_T>(bytes))); return static_cast<CAST_SIZE_T>(bytes);}

--- a/C++/include/cgdk/buffers/_make_shared_buffer.h
+++ b/C++/include/cgdk/buffers/_make_shared_buffer.h
@@ -40,7 +40,7 @@ public:
 };
 
 // alloc_shared_buffer
-inline [[nodiscard]] _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _size)
+inline _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _size)
 {
 	// 1) alloc memory object
 	auto temp = std::make_shared<memory_general>(_size);
@@ -56,7 +56,7 @@ inline [[nodiscard]] _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _si
 }
 
 template <class T>
-[[nodiscard]] _shared_buffer<buffer> _make_shared_buffer(const T& _data)
+_shared_buffer<buffer> _make_shared_buffer(const T& _data)
 {
 	// 1) allocate shared_buffer
 	auto buf_serialized = _alloc_shared_buffer(get_size_of(_data));
@@ -66,25 +66,6 @@ template <class T>
 
 	// 3) do post_process (optional)
 	_do_post_make_shared_buffer<T>(buf_serialized);
-
-	// return) 
-	return buf_serialized;
-}
-
-template <class T>
-[[nodiscard]] _shared_buffer<buffer> _make_shared_buffer()
-{
-	// definition)
-	typedef std::remove_reference_t<std::remove_cv_t<T>> TX;
-
-	// 1) allocate shared_buffer
-	auto buf_serialized = _alloc_shared_buffer(get_size_of(T()));
-
-	// 2) append _data
-	buf_serialized.template append<TX>();
-
-	// 3) do post_process (optional)
-	_do_post_make_shared_buffer<TX>(buf_serialized);
 
 	// return) 
 	return buf_serialized;

--- a/C++/include/cgdk/buffers/_make_shared_buffer.h
+++ b/C++/include/cgdk/buffers/_make_shared_buffer.h
@@ -40,7 +40,7 @@ public:
 };
 
 // alloc_shared_buffer
-inline _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _size)
+inline [[nodiscard]] _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _size)
 {
 	// 1) alloc memory object
 	auto temp = std::make_shared<memory_general>(_size);
@@ -56,7 +56,7 @@ inline _shared_buffer<buffer> _alloc_shared_buffer(std::size_t _size)
 }
 
 template <class T>
-_shared_buffer<buffer> _make_shared_buffer(const T& _data)
+[[nodiscard]] _shared_buffer<buffer> _make_shared_buffer(const T& _data)
 {
 	// 1) allocate shared_buffer
 	auto buf_serialized = _alloc_shared_buffer(get_size_of(_data));
@@ -66,6 +66,25 @@ _shared_buffer<buffer> _make_shared_buffer(const T& _data)
 
 	// 3) do post_process (optional)
 	_do_post_make_shared_buffer<T>(buf_serialized);
+
+	// return) 
+	return buf_serialized;
+}
+
+template <class T>
+[[nodiscard]] _shared_buffer<buffer> _make_shared_buffer()
+{
+	// definition)
+	typedef std::remove_reference_t<std::remove_cv_t<T>> TX;
+
+	// 1) allocate shared_buffer
+	auto buf_serialized = _alloc_shared_buffer(get_size_of(T()));
+
+	// 2) append _data
+	buf_serialized.template append<TX>();
+
+	// 3) do post_process (optional)
+	_do_post_make_shared_buffer<TX>(buf_serialized);
 
 	// return) 
 	return buf_serialized;

--- a/C++/include/cgdk/buffers/_shared_buffer.h
+++ b/C++/include/cgdk/buffers/_shared_buffer.h
@@ -43,21 +43,21 @@ public:
 public:
 	constexpr _shared_buffer() noexcept {}
 	constexpr _shared_buffer(const self_t& _copy) noexcept : base_t(_copy), psource(_copy.psource) {}
-	constexpr _shared_buffer(self_t&& _move) noexcept : base_t(static_cast<base_t&>(_move)), psource(std::move(_move.psource)) {}
+	constexpr _shared_buffer(self_t&& _move) noexcept : base_t(static_cast<base_t&>(_move)), psource(std::move(_move.psource)) { _move = base_t{}; }
 			template<class T>
 	constexpr _shared_buffer(const _shared_buffer<T>& _copy) noexcept : base_t(_copy), psource(_copy.psource) {}
 			template<class T>
-	constexpr _shared_buffer(_shared_buffer<T>&& _move) noexcept : base_t(_move), psource(std::move(_move.psource)) {}
+			constexpr _shared_buffer(_shared_buffer<T>&& _move) noexcept : base_t(_move), psource(std::move(_move.psource)) { _move = base_t{}; }
 	constexpr _shared_buffer(const base_t& _buffer) noexcept : base_t(_buffer) {}
-	constexpr _shared_buffer(base_t&& _buffer) noexcept : base_t(std::move(_buffer)) {}
+	constexpr _shared_buffer(base_t&& _buffer) noexcept : base_t(std::move(_buffer)) { _buffer = base_t{}; }
 
 protected:
 #if defined(_CGDK)
 	constexpr _shared_buffer(const base_t& _buffer, Imemory* _psource) noexcept : base_t(_buffer), psource(_psource) {}
-	constexpr _shared_buffer(base_t&& _buffer, Imemory* _psource) noexcept : base_t(std::move(_buffer)), psource(_psource) {}
+	constexpr _shared_buffer(base_t&& _buffer, Imemory* _psource) noexcept : base_t(std::move(_buffer)), psource(_psource) { _buffer = base_t{}; }
 #else
 	constexpr _shared_buffer(const base_t& _buffer, const object_ptr_t& _psource) noexcept : base_t(_buffer), psource(_psource) {}
-	constexpr _shared_buffer(base_t&& _buffer, object_ptr_t& _psource) noexcept : base_t(std::move(_buffer)), psource(_psource) {}
+	constexpr _shared_buffer(base_t&& _buffer, object_ptr_t& _psource) noexcept : base_t(std::move(_buffer)), psource(_psource) { _buffer = base_t{}; }
 #endif
 
 public:
@@ -140,19 +140,19 @@ public:
 	constexpr std::enable_if_t<std::is_base_of_v<_buffer_view<typename T::element_t>, T>, self_t&>
 								operator += (const _buffer_view<T>(&_rhs)[N] ) { const T* iter = _rhs; const T* iter_end = _rhs + N; for(;iter != iter_end; ++iter) { if (iter->empty()) continue; _append_bytes(iter->size(), iter->data());	} return *this;	}
 	constexpr self_t&			operator += (const self_t& _rhs) { this->_append_bytes(_rhs.size(), _rhs.data()); return *this;}
-	constexpr self_t&			operator += (self_t&& _rhs) { this->_append_bytes(_rhs.size(), _rhs.data()); return *this;}
+	constexpr self_t&			operator += (self_t&& _rhs) { this->_append_bytes(_rhs.size(), _rhs.data()); _rhs = base_t{}; return *this;}
 	constexpr self_t&			operator -= (std::size_t _rhs) { this->data_ -= _rhs; this->size_ += _rhs; return *this;}
 			// [operator] =
 			template <class T>			    
 	constexpr self_t&			operator =  (const _buffer_view<T>& _rhs) noexcept { base_t::operator=(_rhs); return *this;}
 			template <class T>			    
-	constexpr self_t&			operator =  (_buffer_view<T>&& _rhs) noexcept { base_t::operator=(_rhs); return *this;}
+	constexpr self_t&			operator =  (_buffer_view<T>&& _rhs) noexcept { base_t::operator=(std::move(_rhs)); return *this;}
 			template<class T>			    
 	constexpr self_t&			operator =  (const buffer_base<T>& _rhs) { base_t::operator=(_rhs); return *this;}
 			template<class T>			    
-	constexpr self_t&			operator =  (buffer_base<T>&& _rhs) { base_t::operator=(_rhs); return *this;}
+	constexpr self_t&			operator =  (buffer_base<T>&& _rhs) { base_t::operator=(std::move(_rhs)); return *this;}
 	constexpr self_t&			operator =  (const self_t& _rhs) noexcept { this->psource = _rhs.get_source(); base_t::operator=(_rhs); return *this;}
-	constexpr self_t&			operator =  (self_t&& _rhs) noexcept { this->psource = std::move(_rhs.psource); base_t::operator=(_rhs); return *this;}
+	constexpr self_t&			operator =  (self_t&& _rhs) noexcept { this->psource = std::move(_rhs.psource); base_t::operator=(std::move(_rhs)); return *this;}
 			self_t&				operator =  (Imemory* _rhs) noexcept { base_t::operator=(to_base_t<BASE_T>::casting(_rhs)); this->psource = _rhs; return *this;}
 			self_t&				operator =  (const object_ptr_t& _rhs) noexcept { base_t::operator=(to_base_t<BASE_T>::casting(_rhs)); this->psource = _rhs; return *this; }
 			self_t&				operator =  (object_ptr_t&& _rhs) noexcept { base_t::operator=(to_base_t<BASE_T>::casting(_rhs.get())); this->psource = std::move(_rhs); return *this; }
@@ -161,11 +161,11 @@ public:
 			template<class T>
 	constexpr self_t&			operator ^= (const _buffer_view<T>& _rhs) { base_t::operator=(_rhs); return *this;}
 			template<class T>
-	constexpr self_t&			operator ^= (_buffer_view<T>&& _rhs) { base_t::operator=(_rhs); return *this;}
+	constexpr self_t&			operator ^= (_buffer_view<T>&& _rhs) { base_t::operator=(std::move(_rhs)); return *this;}
 			template<class T>
 	constexpr self_t&			operator ^= (const buffer_base<T>& _rhs) { base_t::operator=(_rhs); return *this;}
 			template<class T>
-	constexpr self_t&			operator ^= (buffer_base<T>&& _rhs) { base_t::operator=(_rhs); return *this;}
+	constexpr self_t&			operator ^= (buffer_base<T>&& _rhs) { base_t::operator=(std::move(_rhs)); return *this;}
 	constexpr self_t&			operator ^= (std::size_t _rhs) { base_t::set_size(_rhs); return *this;}
 			// [operator] >> - extract
 			template <class T>
@@ -192,9 +192,9 @@ public:
 			template<class BUFFER_T>
 	constexpr _shared_buffer<BUFFER_T> _extract_shared_buffer();
 protected:
-	constexpr void				_change_source(object_ptr_t&& _pmem_new) noexcept { if(this->size_ > 0) { ::memcpy(_pmem_new->data(), this->data_, this->size_);} this->data_ = _pmem_new->data(); _set_source(std::move(_pmem_new));}
+	constexpr void				_change_source(object_ptr_t&& _pmem_new) noexcept { if(this->size_ > 0) { ::memcpy(_pmem_new->data(), this->data_, this->size_);} this->data_ = _pmem_new->data(); _set_source(std::move(_pmem_new)); _pmem_new.reset(); }
 	constexpr void				_set_source(Imemory* _pmem_new) noexcept { this->psource = _pmem_new; base_t::_set_bound(_pmem_new->get_bound());}
-	constexpr void				_set_source(object_ptr_t&& _pmem_new) noexcept { this->psource = std::move(_pmem_new); base_t::_set_bound(this->psource->get_bound());}
+	constexpr void				_set_source(object_ptr_t&& _pmem_new) noexcept { this->psource = std::move(_pmem_new); base_t::_set_bound(this->psource->get_bound()); _pmem_new.reset(); }
 
 private:
 			object_ptr_t		psource;

--- a/C++/include/cgdk/buffers/_shared_buffer.h
+++ b/C++/include/cgdk/buffers/_shared_buffer.h
@@ -143,11 +143,15 @@ public:
 	constexpr self_t&			operator += (self_t&& _rhs) { this->_append_bytes(_rhs.size(), _rhs.data()); _rhs = base_t{}; return *this;}
 	constexpr self_t&			operator -= (std::size_t _rhs) { this->data_ -= _rhs; this->size_ += _rhs; return *this;}
 			// [operator] =
-			template <class T>			    
+			template <class T>
+	constexpr self_t&			operator =  (const _basic_buffer<T>& _rhs) noexcept { base_t::operator=(_rhs); return *this;}
+			template <class T>
+	constexpr self_t&			operator =  (_basic_buffer<T>&& _rhs) noexcept { base_t::operator=(std::move(_rhs)); return *this;}
+			template <class T>
 	constexpr self_t&			operator =  (const _buffer_view<T>& _rhs) noexcept { base_t::operator=(_rhs); return *this;}
-			template <class T>			    
+			template <class T>
 	constexpr self_t&			operator =  (_buffer_view<T>&& _rhs) noexcept { base_t::operator=(std::move(_rhs)); return *this;}
-			template<class T>			    
+			template<class T>
 	constexpr self_t&			operator =  (const buffer_base<T>& _rhs) { base_t::operator=(_rhs); return *this;}
 			template<class T>			    
 	constexpr self_t&			operator =  (buffer_base<T>&& _rhs) { base_t::operator=(std::move(_rhs)); return *this;}
@@ -238,7 +242,7 @@ constexpr _shared_buffer<BUFFER_T> _shared_buffer<BASE_T>::_extract_shared_buffe
 }
 
 template <class T>
-constexpr CGDK::_shared_buffer<T> operator ^ (const CGDK::_shared_buffer<T>& _lhs, size_t _size)
+constexpr CGDK::_shared_buffer<T> operator ^ (const CGDK::_shared_buffer<T>& _lhs, std::size_t _size)
 {
 	CGDK::_shared_buffer<T> x = _lhs;
 	x.set_size(_size);

--- a/C++/unit_test/unit_test.function/test_buffer_view.cpp
+++ b/C++/unit_test/unit_test.function/test_buffer_view.cpp
@@ -253,18 +253,18 @@ namespace CGDK
 		CGDK::buffer buf_test = CGDK::buffer{ buf_array } + size(OFFSET) + offset(OFFSET);
 
 		// - 값 써넣기
-		buf_test.prepend(strTest1);
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
-		buf_test.prepend_string(std::string_view{ "Test {} {}" }, 10, 20);
+		buf_test.prepend(strTest3);
+	#if defined(__cpp_lib_format)
+		buf_test.prepend(std::format("Test {} {}", 10, 20));
 	#endif
-		buf_test.prepend_string(strTest3);
+		buf_test.prepend(strTest1);
 
 		// - 값 읽기
-		[[maybe_unused]] auto str_read_3 = buf_test.extract<std::string_view>();
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
+		[[maybe_unused]] auto str_read_1 = buf_test.extract<std::string_view>();
+	#if defined(__cpp_lib_format)
 		[[maybe_unused]] auto str_read_2 = buf_test.extract<std::string_view>();
 	#endif
-		[[maybe_unused]] auto str_read_1 = buf_test.extract<std::string_view>();
+		[[maybe_unused]] auto str_read_3 = buf_test.extract<std::string_view>();
 
 		// check) 
 		EXPECT_TRUE(buf_test.size() == 0);
@@ -272,7 +272,7 @@ namespace CGDK
 		EXPECT_TRUE(strTest3 == str_read_3);
 	}
 
-	TEST(CGDK_buffer_view, buffer_append_string)
+	TEST(CGDK_buffer_view, buffer_append_string_view)
 	{
 		// Defintions)
 		std::string_view str_test{ "Test String" };
@@ -289,15 +289,30 @@ namespace CGDK
 		// check) 
 		EXPECT_TRUE(buf_test.size() == get_size_of(str_test));
 
+		// - 값 써넣기
+		buf_test.append(std::string_view(str_test));
+
+		// check) 
+		EXPECT_TRUE(buf_test.size() == (get_size_of(str_test) + get_size_of(std::string_view(str_test))));
+
 		// - 값 읽기
-		auto str_read = buf_test.extract<std::string_view>();
+		auto str_read1 = buf_test.extract<std::string_view>();
+
+		// check) 
+		EXPECT_TRUE(buf_test.size() == get_size_of(std::string_view(str_test)));
+
+		// - 값 읽기
+		auto str_read2 = buf_test.extract<std::string_view>();
 
 		// check) 
 		EXPECT_TRUE(buf_test.size() == 0);
-		EXPECT_TRUE(str_test == str_read);
+
+		// check) 
+		EXPECT_TRUE(str_test == str_read1);
+		EXPECT_TRUE(str_test == str_read2);
 	}
 
-	TEST(CGDK_buffer_view, buffer_append_string_view)
+	TEST(CGDK_buffer_view, buffer_append_string)
 	{
 		// Defintions)
 		std::string	str_test{ "Test String" };
@@ -314,12 +329,27 @@ namespace CGDK
 		// check) 
 		EXPECT_TRUE(buf_temp.size() == get_size_of(str_test));
 
+		// - 값 써넣기
+		buf_temp.append(std::string(str_test));
+
+		// check) 
+		EXPECT_TRUE(buf_temp.size() == (get_size_of(str_test) + get_size_of(std::string(str_test))));
+
 		// - 값 읽기
-		auto str_read = buf_temp.extract<std::string_view>();
+		auto str_read1 = buf_temp.extract<std::string>();
+
+		// check) 
+		EXPECT_TRUE(buf_temp.size() == get_size_of(std::string(str_test)));
+
+		// check) 
+		auto str_read2 = buf_temp.extract<std::string>();
 
 		// check) 
 		EXPECT_TRUE(buf_temp.size() == 0);
-		EXPECT_TRUE(std::char_traits<char>::compare(str_test.data(), str_read.data(), 0)==0);
+
+		// check) 
+		EXPECT_TRUE(std::char_traits<char>::compare(str_test.data(), str_read1.data(), 0) == 0);
+		EXPECT_TRUE(std::char_traits<char>::compare(str_test.data(), str_read2.data(), 0) == 0);
 	}
 
 	TEST(CGDK_buffer_view, buffer_append_string_format)
@@ -331,13 +361,13 @@ namespace CGDK
 		CGDK::buffer buf_temp{ buf_array };
 
 		// - 값 써넣기
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
-		buf_temp.append(std::string_view{ "Test {} {}" }, 10, 20);
+	#if defined(__cpp_lib_format)
+		buf_temp.append(std::format("Test {} {}", 10, 20));
 	#endif
 		buf_temp.append(std::string_view{ "Test" });
 
 		// - 값 읽기
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
+	#if defined(__cpp_lib_format)
 		[[maybe_unused]] auto str_read_1 = buf_temp.extract<std::string_view>();
 	#endif
 		[[maybe_unused]] auto str_read_2 = buf_temp.extract<std::string_view>();
@@ -4593,7 +4623,7 @@ namespace CGDK
 		{
 			CGDK::buffer buf_test = buf_alloc;
 
-			const auto str_test = "test string";
+			const std::string_view str_test = "test string";
 
 			// - append text
 			buf_test.append_text<char>(str_test);
@@ -4608,7 +4638,7 @@ namespace CGDK
 		{
 			CGDK::buffer buf_test = buf_alloc;
 
-			const auto str_test = L"test string";
+			const std::wstring_view str_test = L"test string";
 
 			// - append text
 			buf_test.append_text<wchar_t>(str_test);

--- a/C++/unit_test/unit_test.function/test_shared_buffer.cpp
+++ b/C++/unit_test/unit_test.function/test_shared_buffer.cpp
@@ -230,18 +230,18 @@ namespace CGDK
 		auto buf_test = (buf_temp ^ OFFSET) + offset(OFFSET);
 
 		// - 값 써넣기
-		buf_test.prepend(strTest1);
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
-		buf_test.prepend_string(std::string_view{ "Test {} {}" }, 10, 20);
+		buf_test.prepend(strTest3);
+	#if defined(__cpp_lib_format)
+		buf_test.prepend(std::format("Test {} {}", 10, 20));
 	#endif
-		buf_test.prepend_string(strTest3);
+		buf_test.prepend(strTest1);
 
 		// - 값 읽기
-		[[maybe_unused]] auto str_read_3 = buf_test.extract<std::string_view>();
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
+		[[maybe_unused]] auto str_read_1 = buf_test.extract<std::string_view>();
+	#if defined(__cpp_lib_format)
 		[[maybe_unused]] auto str_read_2 = buf_test.extract<std::string_view>();
 	#endif
-		[[maybe_unused]] auto str_read_1 = buf_test.extract<std::string_view>();
+		[[maybe_unused]] auto str_read_3 = buf_test.extract<std::string_view>();
 
 		// check) 
 		EXPECT_TRUE(buf_test.size() == 0);
@@ -299,13 +299,13 @@ namespace CGDK
 		auto buf_temp = alloc_shared_buffer(2048);
 
 		// - 값 써넣기
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
-		buf_temp.append(std::string_view{ "Test {} {}" }, 10, 20);
+	#if defined(__cpp_lib_format)
+		buf_temp.append(std::format( "Test {} {}", 10, 20) );
 	#endif
 		buf_temp.append(std::string_view{ "Test" });
 
 		// - 값 읽기
-	#if defined(FMT_FORMAT_H_) || (defined(__cpp_lib_format) && defined(_FORMAT_))
+	#if defined(__cpp_lib_format)
 		[[maybe_unused]] auto str_read_1 = buf_temp.extract<std::string_view>();
 	#endif
 		[[maybe_unused]] auto str_read_2 = buf_temp.extract<std::string_view>();

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,52 +1,52 @@
 ## CGDK 3.21 (2023.12.4)
    #### (C#)
    * No Unsafe
-   * Roslyn을 이용해 Source Generaion하는 과정
-   * Unit_test를 추가했습니다.(static, const 멤버 테스트) 
-   * 배열의 Append,Extract시 중대 버그 수정
-   * Class/Struct의 크기 계산 중대 버그 수정
+   * ``Roslyn``을 이용해 ``Source Generaion``하는 과정
+   * Unit_test를 추가했습니다.(``static``, ``const`` 멤버 테스트) 
+   * 배열의 ``Append``,``Extract``시 중대 버그 수정
+   * ``class``/``struct``의 크기 계산 중대 버그 수정
      
 ## CGDK 3.20 (2023.12.1)
    #### (C#)
    * 성능 최적화 
-     - Boxing/Unboxing의 최소화 (Enumerator를 최대한 Boxing/Unboxing이 발생하지 않는 것으로 선택)
-     - List<T>, Dictionary<T>에서 Capacity를 미리 확보하는 처리 추가
+     - ``Boxing/Unboxing``의 최소화 (``Enumerator``를 최대한 ``Boxing/Unboxing``이 발생하지 않는 것으로 선택)
+     - ``List<T>``, ``Dictionary<T>``에서 ``Capacity``를 미리 확보하는 처리 추가
    * Nuget에 대응
      - Nuget에 대응해 Project 설정 변경
-   * Roslyn을 이용해 Source Generaion하는 과정에서 오류 메시지 추가
-     - Source Ganeration 하는 과정에서 오류가 발생하면 Error 메시지가 제대로 출력하도록 처리했습니다.
+   * ``Roslyn``을 이용해 ``Source Generaion``하는 과정에서 오류 메시지 추가
+     - ``Source Ganeration`` 하는 과정에서 오류가 발생하면 Error 메시지가 제대로 출력하도록 처리했습니다.
 
 ## CGDK 3.10 (2023.11.26)
    #### (C#)
-   * Roslyn을 사용해 Source generator를 추가
-     - Serializer를 struct & class 전용 Serializer를 Source generator를 사용해 생성<br>
-     - struct & class의 성능 대폭 향상
+   * ``Roslyn``을 사용해 ``Source generator``를 추가
+     - ``Serializer``를 ``struct`` & ``class`` 전용 ``Serializer``를 ``Source generator``를 사용해 생성<br>
+     - ``struct`` & ``class``의 성능 대폭 향상
    * Documentation Comment 
      - C#에서 제공하는 xml을 사용한 Documentation Comment에 맞춰 주요 클래스와 주요 함수의 주석화 처리를 했습니다.
 
 ## CGDK 3.03.(5) (2023.11.23)
    #### (C#)
    * 8년만에 완전 구조 변경
-     - 실시간 Reflection를 사용하지 않고 Serializer를 생성해 직렬화/역직렬화 수행<br>
-       (즉, 매번 직렬화/역직렬화할 때마다 reflection을 사용하지 않고 한번만 Reflection으로 Serializer를 생성해 직렬화/역직렬화를 함) <br>
-     - 성능의 비약성 향상(struct & class를 제외하고는 MemoryPack에 비해서도 앞도적 성능을 제공)<br>
-       (struct & class 직렬화/역직렬화 성능은 향상되지 않음.) <br>
-     - Roslyn과 Souce Ganetratation을 이용한 버전은 이번 업데이트에서 제외 <br>
+     - 실시간 ``Reflection``를 사용하지 않고 ``Serializer``를 생성해 직렬화/역직렬화 수행<br>
+       (즉, 매번 직렬화/역직렬화할 때마다 ``Reflection``을 사용하지 않고 한번만 ``Reflection``으로 ``Serializer``를 생성해 직렬화/역직렬화를 함) <br>
+     - 성능의 비약성 향상(``struct`` & ``class``를 제외하고는 ``MemoryPack``에 비해서도 앞도적 성능을 제공)<br>
+       (``struct`` & ``class`` 직렬화/역직렬화 성능은 향상되지 않음.) <br>
+     - ``Roslyn``과 ``Souce Ganetratation``을 이용한 버전은 이번 업데이트에서 제외 <br>
       <br>
    * 명명 방식을 C# 표준안에 따르게 수정 <br>
      - 전부 소문자 + '_' 명명 방식을 첫글자 대문자 방식으로 변경 <br>
        따라서 이름이 아래와 같은 방식으로 변경되었다. <br>
        <br>
-         append => __Append__ <br>
-         extract => __Extract__ <br>
-         get_size_of => __GetSizeOf__ <br>
-         get_front => __GetFront__ <br>
-         set_front => __SetFront__ <br>
+         ``append`` => __``Append``__ <br>
+         ``extract`` => __``Extract``__ <br>
+         ``get_size_of`` => __``GetSizeOf``__ <br>
+         ``get_front`` => __``GetFront``__ <br>
+         ``set_front`` => __``SetFront``__ <br>
          ... <br>
          <br>
    * 파일 분리 <br>
-     - .NET, .NET core, .NET framework의 소스파일을 분리 <br>
-       (nullable, Unsafe, Linq 등 문법이 너무 상이해 더이상 코드의 공용이 힘들다고 판단) <br>
+     - ``.NET``, ``.NET core``, ``.NET framework``의 소스파일을 분리 <br>
+       (``nullable``, ``Unsafe``, ``Linq`` 등 문법이 너무 상이해 더이상 코드의 공용이 힘들다고 판단) <br>
 
    * unit test 업데이트. <br>
 
@@ -55,7 +55,7 @@
    * 성능 향상 작업  <br>
      - unsafe를 사용해 일부 기능 성능 향상 <br>
    * Warning 수정 <br>
-     - .NET과 .NET core 컴파일 시 발생하던 Warning 수정 <br>
+     - ``.NET``과 ``.NET core`` 컴파일 시 발생하던 Warning 수정 <br>
    * 디렉토리 재조정 <br>
      - unit_test는 디렉토리를 따로 만들어 분리 <br>
    * CGDK.buffer의 직렬화/역직렬화시 size 저장 변수를 4Byte->8Byte (C++버전과의 호환을 위해) <br>
@@ -63,15 +63,15 @@
 
 ## CGDK 3.03.(3) (2023.11.10) <br>
    #### (C#) <br>
-   * size 형이 short -> Int32 로 변경되었습니다. <br>
-     - C++버전은 size의 기본형(COUNT_T)가 int32_t로 되어 있으므로 그에 맞춰 변경. <br>
+   * ``size`` 형이 ``short`` -> ``Int32`` 로 변경되었습니다. <br>
+     - C++버전은 ``size``의 기본형(``COUNT_T``)가 ``int32_t``로 되어 있으므로 그에 맞춰 변경. <br>
      <br>
 
 ## CGDK 3.03.(2) (2023.11.8, bug fix) <br>
    #### (C++) <br>
    * common <br>
      - unit_test update(버그 수정, 빠진 파일 추가) <br>
-     - flatbuffers unit_test 관련 빠진 파일 업데이트 <br>
+     - ``flatbuffers`` unit_test 관련 빠진 파일 업데이트 <br>
      - 빠진 tutorial file 추가(add mission tutorial) <br>
      - 문서 업데이트(document update) <br>
  <br>
@@ -86,14 +86,14 @@
 ## CGDK 3.02 (2023.10.24) <br>
    #### (C++) <br>
    * common <br>
-     - add_size, sub_size, set_size 같은 함수에 경계정보 검증과정을 추가. <br>
+     - ``add_size``, ``sub_size``, ``set_size`` 같은 함수에 경계정보 검증과정을 추가. <br>
      - 오류와 오타를 수정. <br>
  <br>
 
 ## CGDK 3.01 (2022.07.10) <br>
    #### (C++) <br>
    * common <br>
-     - buffer의 overflow시 assert, exception, 혹은 무반응을 사용자가 설정할 수 있도록 변경<br>
+     - buffer의 overflow시 ``assert``, ``exception``, 혹은 무반응을 사용자가 설정할 수 있도록 변경<br>
         ``` C++
          #define CGDK_NO_BOUND_CHECK // bound 검사를 하지 않음(assert나 exception 던지지 않음)<br>
          #define CGD_DISABLE_ASSERT // bound 범위 밖 조작의 경우에도 assert 발생를 발생하지 않고 (Debug 모드일 때만 해당) 그냥 예외를 바로 짐.<br>
@@ -103,111 +103,112 @@
       최대한 지역 변수의 사용을 최소화함으로 인해 stack에 의한 제한을 많이 완화 했음.<br>
      - unreal 3d를 지원하기 위한 기능. <br>
 
-   * buffer(_basic_buffer) <br>
-     - _basic_buffer(buffer) 배열로 초기화 기능 추가<br>
-     - ramained()함수 추가 - 원본 버퍼의 남은 영역을 buffer로 만들어 리턴해 주는 함수<br>
-     - append시 return값이 모두 reference형에서 오는 오류 수정 (기본형일 경우만 reference 리턴값 가짐)<br>
+   * buffer(``_basic_buffer``) <br>
+     - ``_basic_buffer``(``buffer``) 배열로 초기화 기능 추가<br>
+     - ``remained()``함수 추가 - 원본 버퍼의 남은 영역을 ``buffer``로 만들어 리턴해 주는 함수<br>
+     - ``append``시 return값이 모두 reference형에서 오는 오류 수정 (기본형일 경우만 reference 리턴값 가짐)<br>
      - 중복 코드 제거 <br>
-     - buffer_view의 extract시 오류 수정<br>
-     - extract_multi 시 own_ptr<T> 동작 오류 수정(CGDK10에서 사용할 경우에만 해당)<br>
-   * _shared_buffer <br>
-     - remained()함수 추가. 원본 버퍼의 남은 버퍼를 shared)buffer로 만들어 리턴해주는 함수<br>
+     - ``buffer_view``의 ``extract``시 오류 수정<br>
+     - ``extract_multi`` 시 ``own_ptr<T>`` 동작 오류 수정(``CGDK10``에서 사용할 경우에만 해당)<br>
+   * ``_shared_buffer`` <br>
+     - ``remained()``함수 추가. 원본 버퍼의 남은 버퍼를 ``shared_buffer``로 만들어 리턴해주는 함수<br>
  <br>
    * toturial 정리 <br>
     - tutorial 내용과 설명을 일부 변경<br>
  <br>
 
 ## CGDK 3.0 (2022.07.10) <br>
-   CGD.buffer에서 CGDK.buffer로 명칭 변경<br>
+   ``CGD.buffer``에서 ``CGDK.buffer``로 명칭 변경<br>
    #### (C++) <br>
-   - CGDK::buffer_view, CGDK::buffer, CGDK::shared_buffer로 buffer 세분화<br>
-     CGDK::buffer_view는 extract<T>와 front<T> 기능만 가지며 append<T>는 사용 불가능함.<br>
-     CGDK::buffer는 CGDK::buffer_view를 상속받아 append<T> 기능이 추가됨. <br>
-     CGDK::shared_bufer는 스마트 포인터를 사용한 버퍼가 구현되어 메모리의 해제를 자동 관리함.<br>
+   - ``CGDK::buffer_view``, ``CGDK::buffer``, ``CGDK::shared_buffer``로 ``buffer`` 세분화<br>
+     ``CGDK::buffer_view``는 ``extract<T>``와 ``front<T>`` 기능만 가지며 ``append<T>``는 사용 불가능함.<br>
+     ``CGDK::buffer``는 ``CGDK::buffer_view``를 상속받아 ``append<T>`` 기능이 추가됨. <br>
+     ``CGDK::shared_bufer``는 스마트 포인터를 사용한 버퍼가 구현되어 메모리의 해제를 자동 관리함.<br>
    - 복합형 멤버를 가진 구조체 직렬화 지원<br>
-     std:string, std::vector<T> 등등을 멤버로 가진 구조체(struct 혹은 class)도 append<T>, extract<T>로 바로 직렬화 가능<br>
-   - get_size_of<T>() 직렬화될 크기 업는 함수 추가.<br>
-   - C++17 지원 => std::string_view 등등 ...<br>
-   - C++20 지원 => std::span<T> 등등...<br>
-   - unreal 자료구조 지원 추가 (FString, FStringView, TAraay<T>, TLinkedListBase<T>. TMapBase<K,V> ... 등등<br>
-   - 형식 문자열을 기존 sprintf에서 fmt::format 혹은 std::format 으로 변경<br>
-   - std::tuple<T...>, std::tie<T...> 지원<br>
-   - CGDK::buffer의 append, extract 지원<br>
-   - 문자열 변환 기능을 가진 appened_text<T> 추가<br>
+     ``std:string``, ``std::vector<T>`` 등등을 멤버로 가진 구조체(``struct`` 혹은 ``class``)도 ``append<T>``, ``extract<T>``로 바로 직렬화 가능<br>
+   - ``get_size_of<T>()`` 직렬화될 크기 업는 함수 추가.<br>
+   - C++17 지원 => ``std::string_view`` 등등 ...<br>
+   - C++20 지원 => ``std::span<T>`` 등등...<br>
+   - unreal 자료구조 지원 추가 (``FString``, ``FStringView``, ``TAraay<T>``, ``TLinkedListBase<T>``. ``TMapBase<K,V>`` ... 등등<br>
+   - 형식 문자열을 기존 ``sprintf``에서 ``fmt::format`` 혹은 ``std::format`` 으로 변경<br>
+   - ``std::tuple<T...>``, ``std::tie<T...>`` 지원<br>
+   - ``CGDK::buffer``의 ``append``, ``extract`` 지원<br>
+   - 문자열 변환 기능을 가진 ``appened_text<T>`` 추가<br>
  <br>
 
    #### (C#)  <br>
-   - get_size_of<T> 지원<br>
-   - .NET, .NET.core, .NET.framework 등등 다양한 플랫폼 지원.<br>
+   - ``get_size_of<T>`` 지원<br>
+   - ``.NET``, ``.NET.core``, ``.NET.framework`` 등등 다양한 플랫폼 지원.<br>
 
 ------------------------------------------------------------------------------------- <br>
 ## 2.0.3pre (2015.7.3)
    #### (C++)
-   - CGD::buffer::extract(SKIP) 함수 추가.<br>
-   - CGD::buffer::operator>>(SKIP) 추가.<br>
-   - CGD::buffer::_prepend_tuple 함수 오타 수정<br>
+   - ``CGD::buffer::extract(SKIP)`` 함수 추가.<br>
+   - ``CGD::buffer::operator>>(SKIP)`` 추가.<br>
+   - ``CGD::buffer::_prepend_tuple`` 함수 오타 수정<br>
    - gcc용 C++11버전 지원<br>
      gcc에서도 C++11지원을 위해 config 수정<br>
      gcc warning disable 추가.<br>
-     gcc일 경우 _aligned_malloc(msvc용) 대신 malloc(stadard c++)으로 사용<br>
-     is_memcopy_able gcc 지원용으로 수정<br>
-   - CGD::TIME 관련 오류 수정<br>
-   - std::tuple<T...> 지원 오류 수정<br>
-   - _Xappend_string_format()함수 리펙토링<br>
+     gcc일 경우 _aligned_malloc(msvc용) 대신 ``malloc``(standard c++)으로 사용<br>
+     ``is_memcopy_able`` gcc 지원용으로 수정<br>
+   - ``CGD::TIME`` 관련 오류 수정<br>
+   - ``std::tuple<T...>`` 지원 오류 수정<br>
+   - ``_Xappend_string_format()``함수 리펙토링<br>
 
 ## 2.0.2pre (2015.6.26)
    #### (C++)
-   - Linux 지원. (Linux GCC, cygwin, MinGW, Solaris,  C++11이상 지원 필요)<br>
+   - Linux 지원. (``Linux GCC``, ``cygwin``, ``MinGW``, ``Solaris``,  C++11이상 지원 필요)<br>
  <br>
 
    - 버그 수정<br>
-     - CGD::buffer::_append_array 함수: _Count가 0개일 경우 _Data가 nullptr라도 허용하도록 수정.<br>
-     - CGD::buffer::_append_array 함수: _Count가 0개일 경우 _Data가 nullptr라도 허용하도록 수정.<br>
-     - CGD::buffer::_extract_string_copy: _LengthInWords 변수명 오류 수정<br>
-     - string 처리 과정 중 NULL이 char형으로 캐티팅되지 않아 뜨는 warning 수정.<br>
-     - struct CGD::text<T>: operator 정의 오류 수정<br>
-     - CGD::_Xextract_container_CGPTR_list 함수 오류 수정<br>
-     - CGD::append_string(const const_string<T,N>& _String): 컴파일 오류 수정<br>
-     - CGD::ptr::_prepend_string_format() 함수 오타로 인한 컴파일 오류 수정.<br>
-     - CGD::ptr::_append_string_format 스트링 길이 계산 오류 수정<br>
-     - CGD::ptr::_extract_string_copy()함수 파라미터 이름 오류 수정.<br>
+     - ``CGD::buffer::_append_array`` 함수: ``_Count``가 0개일 경우 _Data가 ``nullptr``라도 허용하도록 수정.<br>
+     - ``CGD::buffer::_append_array`` 함수: ``_Count``가 0개일 경우 _Data가 ``nullptr``라도 허용하도록 수정.<br>
+     - ``CGD::buffer::_extract_string_copy``: ``_LengthInWords`` 변수명 오류 수정<br>
+     - ``string`` 처리 과정 중 ``NULL``이 ``char``형으로 캐티팅되지 않아 뜨는 warning 수정.<br>
+     - ``struct CGD::text<T>: operator`` 정의 오류 수정<br>
+     - ``CGD::_Xextract_container_CGPTR_list`` 함수 오류 수정<br>
+     - ``CGD::append_string(const const_string<T,N>& _String)``: 컴파일 오류 수정<br>
+     - ``CGD::ptr::_prepend_string_format()`` 함수 오타로 인한 컴파일 오류 수정.<br>
+     - ``CGD::ptr::_append_string_format`` 스트링 길이 계산 오류 수정<br>
+     - ``CGD::ptr::_extract_string_copy()``함수 파라미터 이름 오류 수정.<br>
  <br>
 
 ## 2.0.1pre (2015.2.26)
    - visual studio 2010용 Project 추가<br>
-   - C++용 CGD::buffer Example01 내용 보강<br>
-   - C++용 CGD::ptr 오타로 인한 오류 수정<br>
+   - C++용 ``CGD::buffer`` ``Example01`` 내용 보강<br>
+   - C++용 ``CGD::ptr`` 오타로 인한 오류 수정<br>
    - C++용 vs2013 컴파일시 Warning 수정<br>
  <br>
 
 ## 2.0pre (2015.1.5) 
-   - CGCII 프로젝트에서 독립 프로젝트로 분리<br>
-   - CGDK 8.0부터 포함되는 CCGBuffer의 기반<br>
+   - ``CGCII`` 프로젝트에서 독립 프로젝트로 분리<br>
+   - ``CGDK 8.0``부터 포함되는 ``CCGBuffer``의 기반<br>
    - 클래스명 변경<br>
-     CGBUF     -> CGD::buffer <br>
-     CCGMemPtr -> CGD::ptr<br>
+     ``CGBUF``     -> ``CGD::buffer`` <br>
+     ``CCGMemPtr`` -> ``CGD::ptr``<br>
  <br>
-   - 함수명이 전부 소문자로 바뀌었습니다.(예, Append -> append, Extract -> extract)<br>
+   - 함수명이 전부 소문자로 바뀌었습니다.(예, ``Append`` -> ``append``, ``Extract`` -> ``extract``)<br>
    - 함수명이 대폭 변경<br>
-       Append<T>      -> append<T><br>
-       ExtractHead<T> -> extract<T><br>
-       ExtractTail<T> -> subtract<T><br>
-       Head<T>        -> front<T><br>
-       Tail<T>        -> back<T><br>
+  
+       ``Append<T>``      -> ``append<T>``<br>
+       ``ExtractHead<T>`` -> ``extract<T>``<br>
+       ``ExtractTail<T>`` -> ``subtract<T>``<br>
+       ``Head<T>``        -> ``front<T>``<br>
+       ``Tail<T>``        -> ``back<T>``<br>
  <br>
-   - C++11 기준 template meta programming이 적용<br>
-   - meta programming이 적용되어 vector/list 등의 복합형을 동일이름으로 동작가능<br>
-   - meta programming이 적용되어 array, vector<T>와 같은 복합형은 Block copy를 지원해 성능을 향상<br>
-   - std::string/std::wstring뿐만 아니라 char16_t, char32_t 등 다양한 문자열을 지원합니다<br>
-   - literal로 작성된 문자열은 실시간으로 문자열을 길이를 계산하는 것이 아니라 컴파일 타임에 계산되어 적용(constexpr 일부 지원)<br>
-   - vector/array/string 등의 복합형 객체의 다계층을 지원<br>
-   - C#은 struct를 통해 Heterogenous형을 지원<br>
-   - C++버전은 std::tuple을 통해 Heterogenous 복합형을 지원<br>
-   - std::initializer_list를 지원<br>
-   - C++버전은 prepend 기능이 추가<br>
-   - C++버전은 배열형 extract 기능도 추가<br>
-   - 웹서버 통신에 필요한 형식 추가('\r\n'을 사용하는 문자열 처리 추가)<br>
-   - r-value 관련 오류 가능성 수정<br>
+   - C++11 기준 ``template meta programming``이 적용<br>
+   - ``meta programming``이 적용되어 ``vector``/``list`` 등의 복합형을 동일이름으로 동작가능<br>
+   - ``meta programming``이 적용되어 ``array``, ``vector<T>``와 같은 복합형은 Block copy를 지원해 성능을 향상<br>
+   - ``std::string``/``std::wstring``뿐만 아니라 ``char16_t``, ``char32_t`` 등 다양한 문자열을 지원합니다<br>
+   - ``literal``로 작성된 문자열은 실시간으로 문자열을 길이를 계산하는 것이 아니라 컴파일 타임에 계산되어 적용(``constexpr`` 일부 지원)<br>
+   - ``vector``/``array``/``string`` 등의 복합형 객체의 다계층을 지원<br>
+   - C#은 ``struct``를 통해 Heterogenous형을 지원<br>
+   - C++버전은 ``std::tuple``을 통해 Heterogenous 복합형을 지원<br>
+   - ``std::initializer_list``를 지원<br>
+   - C++버전은 ``prepend`` 기능이 추가<br>
+   - C++버전은 배열형 ``extract`` 기능도 추가<br>
+   - 웹서버 통신에 필요한 형식 추가(``'\r\n'``을 사용하는 문자열 처리 추가)<br>
+   - ``r-value`` 관련 오류 가능성 수정<br>
  <br>
 
 ## 1.0   CGDK 7.0까지 포함되어 있던 CCGBuffer     <br>

--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,3 +1,8 @@
+## CGDK 3.22 (2024.3.22)
+   #### (C++)
+   * buffer를 std::move했을 때 data_와 size_값을 nullptr와 0으로 reset 되도록 수정.
+   * gcc-13 컴파일 나는 error 수정.
+     
 ## CGDK 3.21 (2023.12.4)
    #### (C#)
    * No Unsafe


### PR DESCRIPTION
C#
  add unit test
 size가 0인 배열과 List<T>의 append/extract 테스트 추가
 객체가 할당되지 않은(null) List<T>의 append/extract 테스트 추가

c++
* remove  appending/extracting string format 

     buf.append("test {}, {}", 10, 20); // x (removed)
     buf.append(std::format("{}.{}, 10, 20); // o

     buf.append_text("test {}, {}", 10, 20); // x (removed)
     buf.append_text(std::format("{}.{}, 10, 20); // o


     std::format이 일반화 됨에 따라 문자열의 append/extract 시 string format을 제거했습니다.
     그냥 std::format으로 문자열을 만들어서 append하길 권장함.
     이에 따른 unit_test도 수정됨.

* remove pointer type variable string append  
  포인터로 저장된 문자열 변수의 append는 지원하지 않습니다.
  즉, null terminated 문자열의 append는 지원하지 않습니다.
  안정적인 동작을 위해 std::string, std::string_view 혹은 배열형 문자열을 사용하시기 바랍니다.

     안정적인 동작을 위해 
     null terminated 문자열(char* 변수는 문자열)로 append할 수 없습니다. 

        const char* text = "test string"
        buf.append(test); // x

     std::string이나 std::string_view만 append할 수 있습니다.

        std::string_view text = "test string"
        buf.append(test); // o
    
        auto text = "test string"sv;
        buf.append(test); // o

     문자열을 직접 넣으면 문자열로 인식해 가능합니다.

        buf.append("test string"); // 0 

     이에 따른 unit_test도 수정됨.

* bug fix 1
  shared_buffer에서 baskc_buffer로  assign시 bound 정보가 제대로 복사되지 않을 수 있었던 버그 수정

* buf fix 2
  unit test 시 실패 확인 오류 수정 
